### PR TITLE
add `T_CMB` and `g0` to parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.3.10
+:Version: 2.3.11
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 """:mod:`primpy.__version__`: version file for primpy."""
 
-__version__ = '2.3.10'
+__version__ = '2.3.11'

--- a/primpy/inflation.py
+++ b/primpy/inflation.py
@@ -6,8 +6,8 @@ import numpy as np
 from scipy.interpolate import interp1d
 from scipy.misc import derivative
 from primpy.exceptionhandling import CollapseWarning, InflationStartWarning, InflationEndWarning
-from primpy.units import pi, c, a_B, mp_kg, lp_m, Mpc_m
-from primpy.parameters import T_CMB, K_STAR
+from primpy.units import pi, c, lp_m, Mpc_m
+from primpy.parameters import K_STAR, rho_r0_mp_ilp3
 from primpy.equations import Equations
 
 
@@ -101,10 +101,8 @@ class InflationEquations(Equations, ABC):
             """Derive the scale factor today `a_0` either from reheating or from `Omega_K0`."""
             # derive a0 and Omega_K0 from reheating:
             if Omega_K0 is None:
-                rho_r0_SI = a_B * T_CMB**4 / c**2  # TODO: fix rho_r0 = rho_photon0 + rho_nu0 ?
-                rho_r0 = rho_r0_SI / mp_kg * lp_m**3
                 # just from instant reheating:
-                N0 = sol.N_end + np.log(3 / 2) / 4 + np.log(sol.V_end / rho_r0) / 4
+                N0 = sol.N_end + np.log(3 / 2) / 4 + np.log(sol.V_end / rho_r0_mp_ilp3) / 4
                 # additional term from general reheating:
                 if delta_reh is not None and w_reh is not None:
                     N0 += (1 - 3 * w_reh) * delta_reh / 4

--- a/primpy/parameters.py
+++ b/primpy/parameters.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """:mod:`primpy.parameters`: constants and parameters for primpy."""
-from primpy.units import c, a_B, Mpc_m, lp_m, Tp_K
+from primpy.units import c, a_B, Mpc_m, mp_kg, lp_m, Tp_K
 
 # wavenumber at pivot scale in units of [Mpc-1]
 K_STAR = 0.05
@@ -17,6 +17,7 @@ z_BBN = 1e9  # rough estimate of redshift of Big Bang Nucleosynthesis
 
 # derived parameters
 g0 = 2 + 7/8 * 2 * N_eff * T_nu_TCMB**3
-rho_gamma0_kg_im3 = a_B * T_CMB_K**4 / c**2  # in SI units
-rho_nu0_kg_im3 = 7/8 * N_eff * T_nu_TCMB**4 * rho_gamma0_kg_im3
-rho_r0_kg_im3 = rho_gamma0_kg_im3 + rho_nu0_kg_im3
+rho_gamma0_kg_im3 = a_B * T_CMB_K**4 / c**2                      # in SI units
+rho_nu0_kg_im3 = 7/8 * N_eff * T_nu_TCMB**4 * rho_gamma0_kg_im3  # in SI units
+rho_r0_kg_im3 = rho_gamma0_kg_im3 + rho_nu0_kg_im3               # in SI units
+rho_r0_mp_ilp3 = rho_r0_kg_im3 / mp_kg * lp_m**3                 # in reduced Planck units

--- a/primpy/parameters.py
+++ b/primpy/parameters.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python
 """:mod:`primpy.parameters`: constants and parameters for primpy."""
-from primpy.units import c, a_B
+from primpy.units import c, a_B, Mpc_m, lp_m, Tp_K
 
 # wavenumber at pivot scale in units of [Mpc-1]
 K_STAR = 0.05
+K_STAR_lp = K_STAR / Mpc_m * lp_m
 
 # hard coded parameters
-T_CMB = 2.72548  # +- 0.00057, in Kelvin, arXiv:0911.1955
-N_eff = 3.046
+T_CMB_K = 2.72548  # +- 0.00057, in Kelvin, arXiv:0911.1955
+T_CMB_Tp = T_CMB_K / Tp_K
+T_nu_TCMB = (4 / 11)**(1/3)  # T_ncdm in CLASS
+T_nu_K = T_nu_TCMB * T_CMB_K
+T_nu_Tp = T_nu_K / Tp_K
+N_eff = 3.044  # equivalent to N_ur in CLASS for massless neutrinos
 z_BBN = 1e9  # rough estimate of redshift of Big Bang Nucleosynthesis
 
 # derived parameters
-rho_gamma0_kg_im3 = a_B * T_CMB**4 / c**2  # in SI units
-rho_nu0_kg_im3 = N_eff * 7/8 * (4/11)**(4/3) * rho_gamma0_kg_im3
+g0 = 2 + 7/8 * 2 * N_eff * T_nu_TCMB**3
+rho_gamma0_kg_im3 = a_B * T_CMB_K**4 / c**2  # in SI units
+rho_nu0_kg_im3 = 7/8 * N_eff * T_nu_TCMB**4 * rho_gamma0_kg_im3
 rho_r0_kg_im3 = rho_gamma0_kg_im3 + rho_nu0_kg_im3

--- a/primpy/units.py
+++ b/primpy/units.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python
 """:mod:`primpy.units`: units and constants for primpy."""
-
 import numpy as np
 from scipy.constants import mega, giga, parsec as parsec_m
 from scipy.constants import pi, c, hbar, G, k as k_B, e
-
 
 # reduced Planck units in SI
 mp_kg = np.sqrt(hbar * c / (8 * pi * G))
 tp_s = np.sqrt(8 * pi * G * hbar / c**5)
 lp_m = np.sqrt(8 * pi * G * hbar / c**3)
+Tp_K = np.sqrt(hbar * c**5 / (8 * pi * G * k_B**2))
 
 # reduced Planck units in GeV
 mp_GeV = mp_kg * c**2 / (giga * e)
@@ -20,4 +19,4 @@ lp_iGeV = lp_m / hbar / c * giga * e
 Mpc_m = mega * parsec_m
 
 # derived constants
-a_B = 8. * pi**5 * k_B**4 / 15. / (2. * pi * hbar)**3 / c**3  # radiation constant (Planck's law)
+a_B = 8 * pi**5 * k_B**4 / 15 / (2 * pi * hbar)**3 / c**3  # radiation constant (Planck's law)


### PR DESCRIPTION
* add the Planck temperature to units
* add CMB temperature in Planck units to parameters
* add neutrino temperature to parameters
* update `N_eff=3.044` to match value in CLASS
* compute the present-day (entropy) relativistic d.o.f. `g0` in terms of `N_eff` and neutrino temperature


# Checklist:

- [x] I have performed a self-review of my own code.
- [x] My code is PEP8 compliant (`flake8 --max-line-length 99 primpy tests`).
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `anesthetic/__version__.py`.
