### PR TITLE
Slow-roll initial conditions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.3.11
+:Version: 2.4.0
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 """:mod:`primpy.__version__`: version file for primpy."""
 
-__version__ = '2.3.11'
+__version__ = '2.4.0'

--- a/primpy/initialconditions.py
+++ b/primpy/initialconditions.py
@@ -16,8 +16,8 @@ import primpy.bigbang as bb
 class SlowRollIC(object):
     """Slow-roll initial conditions given `phi_i` and either of `N_i` or `Omega_Ki`.
 
-    Class for setting up initial conditions at the start of inflation, when
-    the curvature density parameter was maximal after kinetic dominance.
+    Class for setting up initial conditions during slow-roll inflation where
+    the potential energy dominates over the kinetic energy.
     """
 
     def __init__(self, equations, phi_i, t_i=None, eta_i=None, x_end=1e300, **kwargs):

--- a/primpy/initialconditions.py
+++ b/primpy/initialconditions.py
@@ -13,6 +13,76 @@ import primpy.bigbang as bb
 
 
 # noinspection PyPep8Naming
+class SlowRollIC(object):
+    """Slow-roll initial conditions given `phi_i` and either of `N_i` or `Omega_Ki`.
+
+    Class for setting up initial conditions at the start of inflation, when
+    the curvature density parameter was maximal after kinetic dominance.
+    """
+
+    def __init__(self, equations, phi_i, t_i=None, eta_i=None, x_end=1e300, **kwargs):
+        self.equations = equations
+        self.phi_i = phi_i
+        self.t_i = t_i
+        self.eta_i = eta_i
+        self.x_end = x_end
+
+        self.V_i = equations.potential.V(self.phi_i)
+        self.dV_i = equations.potential.dV(self.phi_i)
+        if 'N_i' in kwargs and 'Omega_Ki' not in kwargs:
+            self.N_i = kwargs.pop('N_i')
+            self.ic_input_param = {'N_i': self.N_i}
+            self.aH2_i = self.V_i / 3 * np.exp(2 * self.N_i) - equations.K
+            if self.aH2_i < 0:
+                raise InflationStartError(
+                    "V_i / 3 * exp(2 N_i) - 1 = %s < 0 but needs to be > 0. Increase either N_i "
+                    "or phi_i." % self.aH2_i, geometry="closed")
+            self.aH_i = np.sqrt(self.V_i / 3 * np.exp(2 * self.N_i) - equations.K)
+            self.Omega_Ki = -equations.K / self.aH2_i
+        elif 'Omega_Ki' in kwargs and 'N_i' not in kwargs:
+            self.Omega_Ki = kwargs.pop('Omega_Ki')
+            self.ic_input_param = {'Omega_Ki': self.Omega_Ki}
+            if self.Omega_Ki >= 1:
+                raise InflationStartError(
+                    "Primordial curvature for open universes has to be Omega_Ki < 1, "
+                    "but Omega_Ki = %g was requested." % self.Omega_Ki, geometry="open")
+            self.N_i = np.log(3 * equations.K / self.V_i * (1 - 1 / self.Omega_Ki)) / 2
+            self.aH2_i = -equations.K / self.Omega_Ki
+            self.aH_i = np.sqrt(self.aH2_i)
+        else:
+            raise TypeError("Need to specify either N_i xor Omega_Ki.")
+        self.H_i = self.aH_i * np.exp(-self.N_i)
+        if isinstance(self.equations, InflationEquationsT):
+            self.x_ini = self.t_i
+            self.x_end = self.x_end
+            self.dphidt_i = -self.dV_i / (3 * self.H_i)
+        elif isinstance(self.equations, InflationEquationsN):
+            self.x_ini = self.N_i
+            self.x_end = self.x_end
+            self.dphidN_i = -self.dV_i / (3 * self.H_i**2)
+
+    def __call__(self, y0, **ivp_kwargs):
+        """Set background equations of inflation for `N`, `phi` and `dphi`."""
+        if isinstance(self.equations, InflationEquationsT):
+            y0[self.equations.idx['dphidt']] = self.dphidt_i
+            y0[self.equations.idx['N']] = self.N_i
+        elif isinstance(self.equations, InflationEquationsN):
+            y0[self.equations.idx['dphidN']] = self.dphidN_i
+            if self.equations.track_time:
+                assert self.t_i is not None, ("`track_time=%s`, but `t_i=%s`."
+                                              % (self.equations.track_time, self.t_i))
+                y0[self.equations.idx['t']] = self.t_i
+        else:
+            raise NotImplementedError("`equations` has to be either of type `InflationEquationsT`"
+                                      "or of type `InflationEquationsN`, but type `%s` was given."
+                                      % type(self.equations))
+        y0[self.equations.idx['phi']] = self.phi_i
+        if self.equations.track_eta:
+            assert self.eta_i is not None, ("`track_eta=%s`, but `eta_i=%s`."
+                                            % (self.equations.track_eta, self.eta_i))
+            y0[self.equations.idx['eta']] = self.eta_i
+
+
 class InflationStartIC(object):
     """Inflation start initial conditions given `phi_i` and either of `N_i` or `Omega_Ki`.
 

--- a/tests/test_initialconditions.py
+++ b/tests/test_initialconditions.py
@@ -8,7 +8,7 @@ from primpy.events import InflationEvent
 from primpy.inflation import InflationEquations
 from primpy.time.inflation import InflationEquationsT
 from primpy.efolds.inflation import InflationEquationsN
-from primpy.initialconditions import InflationStartIC, ISIC_Nt, ISIC_NsOk
+from primpy.initialconditions import SlowRollIC, InflationStartIC, ISIC_Nt, ISIC_NsOk
 from primpy.solver import solve
 
 
@@ -22,20 +22,46 @@ def basic_ic_asserts(y0, ic, K, pot, N_i, Omega_Ki, phi_i, t_i):
         assert y0.size == 3
         assert ic.x_ini == t_i
         assert ic.t_i == t_i
-        assert ic.dphidt_i == -np.sqrt(ic.V_i)
         assert y0[1] == ic.dphidt_i
         assert y0[2] == ic.N_i
     elif isinstance(ic.equations, InflationEquationsN):
         assert y0.size == 2
         assert ic.t_i is None
         assert ic.x_ini == N_i
-        assert ic.dphidN_i == -np.sqrt(ic.V_i) / ic.H_i
         assert y0[1] == ic.dphidN_i
     assert ic.equations.K == K
     assert ic.equations.potential.V(phi_i) == pot.V(phi_i)
     assert ic.equations.potential.dV(phi_i) == pot.dV(phi_i)
     assert ic.equations.potential.d2V(phi_i) == pot.d2V(phi_i)
     assert ic.equations.potential.d3V(phi_i) == pot.d3V(phi_i)
+
+
+@pytest.mark.parametrize('pot', [QuadraticPotential(Lambda=np.sqrt(6e-6)),
+                                 StarobinskyPotential(Lambda=5e-2)])
+@pytest.mark.parametrize('K', [-1, 0, +1])
+@pytest.mark.parametrize('t_i, Eq', [(1e4, InflationEquationsT), (None, InflationEquationsN)])
+def test_SlowRollIC(pot, K, t_i, Eq):
+    phi_i = 17
+
+    # for N_i:
+    N_i = 12
+    eq = Eq(K=K, potential=pot)
+    with pytest.raises(TypeError, match="Need to specify either N_i xor Omega_Ki."):
+        SlowRollIC(equations=eq, phi_i=phi_i, t_i=t_i)
+    ic = SlowRollIC(equations=eq, N_i=N_i, phi_i=phi_i, t_i=t_i)
+    y0 = np.zeros(len(ic.equations.idx))
+    ic(y0)
+    basic_ic_asserts(y0, ic, K, pot, N_i, ic.Omega_Ki, phi_i, t_i)
+
+    # for Omega_Ki:
+    if K != 0:
+        with pytest.raises(Exception, match="Primordial curvature for open universes"):
+            SlowRollIC(equations=eq, Omega_Ki=1, phi_i=phi_i, t_i=t_i)
+        Omega_Ki = -K * 0.9
+        ic = SlowRollIC(equations=eq, Omega_Ki=Omega_Ki, phi_i=phi_i, t_i=t_i)
+        y0 = np.zeros(len(ic.equations.idx))
+        ic(y0)
+        basic_ic_asserts(y0, ic, K, pot, ic.N_i, Omega_Ki, phi_i, t_i)
 
 
 @pytest.mark.parametrize('pot', [QuadraticPotential(Lambda=np.sqrt(6e-6)),
@@ -59,6 +85,10 @@ def test_InflationStartIC(pot, K, t_i, Eq):
     y0 = np.zeros(len(ic.equations.idx))
     ic(y0)
     basic_ic_asserts(y0, ic, K, pot, N_i, ic.Omega_Ki, phi_i, t_i)
+    if isinstance(ic.equations, InflationEquationsT):
+        assert ic.dphidt_i == -np.sqrt(ic.V_i)
+    elif isinstance(ic.equations, InflationEquationsN):
+        assert ic.dphidN_i == -np.sqrt(ic.V_i) / ic.H_i
 
     # for Omega_Ki:
     if K != 0:
@@ -69,6 +99,10 @@ def test_InflationStartIC(pot, K, t_i, Eq):
         y0 = np.zeros(len(ic.equations.idx))
         ic(y0)
         basic_ic_asserts(y0, ic, K, pot, ic.N_i, Omega_Ki, phi_i, t_i)
+        if isinstance(ic.equations, InflationEquationsT):
+            assert ic.dphidt_i == -np.sqrt(ic.V_i)
+        elif isinstance(ic.equations, InflationEquationsN):
+            assert ic.dphidN_i == -np.sqrt(ic.V_i) / ic.H_i
         with pytest.raises(Exception, match="Primordial curvature for open universes"):
             InflationStartIC(equations=eq, Omega_Ki=1, phi_i=phi_i, t_i=t_i)
 
@@ -85,6 +119,10 @@ def test_ISIC_Nt_Ni(K, t_i, Eq):
     y0 = np.zeros(len(ic.equations.idx))
     ic(y0)
     basic_ic_asserts(y0, ic, K, pot, N_i, ic.Omega_Ki, ic.phi_i, t_i)
+    if isinstance(ic.equations, InflationEquationsT):
+        assert ic.dphidt_i == -np.sqrt(ic.V_i)
+    elif isinstance(ic.equations, InflationEquationsN):
+        assert ic.dphidN_i == -np.sqrt(ic.V_i) / ic.H_i
     assert ic.N_tot == N_tot
     ev = [InflationEvent(ic.equations, +1, terminal=False),
           InflationEvent(ic.equations, -1, terminal=True)]
@@ -113,6 +151,10 @@ def test_ISIC_Nt_Oi(K, abs_Omega_Ki, t_i, Eq):
         y0 = np.zeros(len(ic.equations.idx))
         ic(y0)
         basic_ic_asserts(y0, ic, K, pot, ic.N_i, Omega_Ki, ic.phi_i, t_i)
+        if isinstance(ic.equations, InflationEquationsT):
+            assert ic.dphidt_i == -np.sqrt(ic.V_i)
+        elif isinstance(ic.equations, InflationEquationsN):
+            assert ic.dphidN_i == -np.sqrt(ic.V_i) / ic.H_i
         assert ic.N_tot == N_tot
         ev = [InflationEvent(ic.equations, +1, terminal=False),
               InflationEvent(ic.equations, -1, terminal=True)]
@@ -141,6 +183,10 @@ def test_ISIC_NsOk(K, t_i, Eq):
     y0 = np.zeros(len(ic.equations.idx))
     ic(y0)
     basic_ic_asserts(y0, ic, K, pot, N_i, ic.Omega_Ki, ic.phi_i, t_i)
+    if isinstance(ic.equations, InflationEquationsT):
+        assert ic.dphidt_i == -np.sqrt(ic.V_i)
+    elif isinstance(ic.equations, InflationEquationsN):
+        assert ic.dphidN_i == -np.sqrt(ic.V_i) / ic.H_i
     assert ic.N_star == N_star
     assert ic.Omega_K0 == Omega_K0
     assert ic.h == h
@@ -161,6 +207,10 @@ def test_ISIC_NsOk(K, t_i, Eq):
     y0 = np.zeros(len(ic.equations.idx))
     ic(y0)
     basic_ic_asserts(y0, ic, K, pot, ic.N_i, Omega_Ki, ic.phi_i, t_i)
+    if isinstance(ic.equations, InflationEquationsT):
+        assert ic.dphidt_i == -np.sqrt(ic.V_i)
+    elif isinstance(ic.equations, InflationEquationsN):
+        assert ic.dphidN_i == -np.sqrt(ic.V_i) / ic.H_i
     assert ic.N_star == N_star
     assert ic.Omega_K0 == Omega_K0
     assert ic.h == h


### PR DESCRIPTION
This PR introduces slow-roll initial conditions, where the Universe directly starts in the inflating phase.

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] My code is PEP8 compliant (`flake8 --max-line-length 99 primpy tests`).
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `anesthetic/__version__.py`.
