### PR TITLE
conversion methods from `N_star` to `n_s` and `r`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.5.0
+:Version: 2.6.0
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 """:mod:`primpy.__version__`: version file for primpy."""
 
-__version__ = '2.5.0'
+__version__ = '2.6.0'

--- a/primpy/potentials.py
+++ b/primpy/potentials.py
@@ -180,25 +180,25 @@ class MonomialPotential(InflationaryPotential):
 
     @staticmethod
     def sr_Nstar2ns(N_star, **pot_kwargs):
-        """Slow-roll approximation for inferring `n_s` from `N_star`"""
+        """Slow-roll approximation for inferring `n_s` from `N_star`."""
         p = pot_kwargs.pop('p')
         return 1 - p / (2 * N_star) - 1 / N_star
 
     @staticmethod
     def sr_ns2Nstar(n_s, **pot_kwargs):
-        """Slow-roll approximation for inferring `N_star` from `n_s`"""
+        """Slow-roll approximation for inferring `N_star` from `n_s`."""
         p = pot_kwargs.pop('p')
         return (2 + p) / (2 * (1 - n_s))
 
     @staticmethod
     def sr_Nstar2r(N_star, **pot_kwargs):
-        """Slow-roll approximation for inferring `r` from `N_star`"""
+        """Slow-roll approximation for inferring `r` from `N_star`."""
         p = pot_kwargs.pop('p')
         return 16 * p / (4 * N_star + p)
 
     @staticmethod
     def sr_r2Nstar(r, **pot_kwargs):
-        """Slow-roll approximation for inferring `N_star` from `r`"""
+        """Slow-roll approximation for inferring `N_star` from `r`."""
         p = pot_kwargs.pop('p')
         return p * (16 - r) / (4 * r)
 
@@ -255,19 +255,19 @@ class LinearPotential(MonomialPotential):
         super().__init__(p=1, **pot_kwargs)
 
     @staticmethod
-    def sr_Nstar2ns(N_star, **pot_params):
+    def sr_Nstar2ns(N_star, **pot_params):  # noqa: D102
         return MonomialPotential.sr_Nstar2ns(N_star=N_star, p=1)
 
     @staticmethod
-    def sr_ns2Nstar(n_s, **pot_params):
+    def sr_ns2Nstar(n_s, **pot_params):  # noqa: D102
         return MonomialPotential.sr_ns2Nstar(n_s=n_s, p=1)
 
     @staticmethod
-    def sr_Nstar2r(N_star, **pot_params):
+    def sr_Nstar2r(N_star, **pot_params):  # noqa: D102
         return MonomialPotential.sr_Nstar2r(N_star=N_star, p=1)
 
     @staticmethod
-    def sr_r2Nstar(r, **pot_params):
+    def sr_r2Nstar(r, **pot_params):  # noqa: D102
         return MonomialPotential.sr_r2Nstar(r=r, p=1)
 
     @staticmethod
@@ -336,19 +336,19 @@ class QuadraticPotential(MonomialPotential):
         return np.sqrt(V) / self.Lambda**2
 
     @staticmethod
-    def sr_Nstar2ns(N_star, **pot_kwargs):
+    def sr_Nstar2ns(N_star, **pot_kwargs):  # noqa: D102
         return MonomialPotential.sr_Nstar2ns(N_star=N_star, p=2)
 
     @staticmethod
-    def sr_ns2Nstar(n_s, **pot_kwargs):
+    def sr_ns2Nstar(n_s, **pot_kwargs):  # noqa: D102
         return MonomialPotential.sr_ns2Nstar(n_s=n_s, p=2)
 
     @staticmethod
-    def sr_Nstar2r(N_star, **pot_kwargs):
+    def sr_Nstar2r(N_star, **pot_kwargs):  # noqa: D102
         return MonomialPotential.sr_Nstar2r(N_star=N_star, p=2)
 
     @staticmethod
-    def sr_r2Nstar(r, **pot_kwargs):
+    def sr_r2Nstar(r, **pot_kwargs):  # noqa: D102
         return MonomialPotential.sr_r2Nstar(r=r, p=2)
 
     @staticmethod
@@ -403,19 +403,19 @@ class CubicPotential(MonomialPotential):
         super().__init__(p=3, **pot_kwargs)
 
     @staticmethod
-    def sr_Nstar2ns(N_star, **pot_kwargs):
+    def sr_Nstar2ns(N_star, **pot_kwargs):  # noqa: D102
         return MonomialPotential.sr_Nstar2ns(N_star=N_star, p=3)
 
     @staticmethod
-    def sr_ns2Nstar(n_s, **pot_kwargs):
+    def sr_ns2Nstar(n_s, **pot_kwargs):  # noqa: D102
         return MonomialPotential.sr_ns2Nstar(n_s=n_s, p=3)
 
     @staticmethod
-    def sr_Nstar2r(N_star, **pot_kwargs):
+    def sr_Nstar2r(N_star, **pot_kwargs):  # noqa: D102
         return MonomialPotential.sr_Nstar2r(N_star=N_star, p=3)
 
     @staticmethod
-    def sr_r2Nstar(r, **pot_kwargs):
+    def sr_r2Nstar(r, **pot_kwargs):  # noqa: D102
         return MonomialPotential.sr_r2Nstar(r=r, p=3)
 
     @staticmethod
@@ -462,19 +462,19 @@ class QuarticPotential(MonomialPotential):
         super().__init__(p=4, **pot_kwargs)
 
     @staticmethod
-    def sr_Nstar2ns(N_star, **pot_kwargs):
+    def sr_Nstar2ns(N_star, **pot_kwargs):  # noqa: D102
         return MonomialPotential.sr_Nstar2ns(N_star=N_star, p=4)
 
     @staticmethod
-    def sr_ns2Nstar(n_s, **pot_kwargs):
+    def sr_ns2Nstar(n_s, **pot_kwargs):  # noqa: D102
         return MonomialPotential.sr_ns2Nstar(n_s=n_s, p=4)
 
     @staticmethod
-    def sr_Nstar2r(N_star, **pot_kwargs):
+    def sr_Nstar2r(N_star, **pot_kwargs):  # noqa: D102
         return MonomialPotential.sr_Nstar2r(N_star=N_star, p=4)
 
     @staticmethod
-    def sr_r2Nstar(r, **pot_kwargs):
+    def sr_r2Nstar(r, **pot_kwargs):  # noqa: D102
         return MonomialPotential.sr_r2Nstar(r=r, p=4)
 
     @staticmethod
@@ -546,7 +546,7 @@ class StarobinskyPotential(InflationaryPotential):
 
     @staticmethod
     def sr_Nstar2ns(N_star):
-        """Slow-roll approximation for inferring `n_s` from `N_star`"""
+        """Slow-roll approximation for inferring `n_s` from `N_star`."""
         gamma = StarobinskyPotential.gamma
         num = 2 * N_star * gamma**2 + np.sqrt(2) * gamma + 2
         den = N_star * gamma * (N_star * gamma + np.sqrt(2))
@@ -554,7 +554,7 @@ class StarobinskyPotential(InflationaryPotential):
 
     @staticmethod
     def sr_ns2Nstar(n_s):
-        """Slow-roll approximation for inferring `N_star` from `n_s`"""
+        """Slow-roll approximation for inferring `N_star` from `n_s`."""
         gamma = StarobinskyPotential.gamma
         num = 2*gamma - np.sqrt(2) * (1-n_s) + np.sqrt(2*(1-n_s)**2 + 8*(1-n_s) + 4*gamma**2)
         den = 2 * gamma * (1-n_s)
@@ -562,13 +562,13 @@ class StarobinskyPotential(InflationaryPotential):
 
     @staticmethod
     def sr_Nstar2r(N_star):
-        """Slow-roll approximation for inferring `r` from `N_star`"""
+        """Slow-roll approximation for inferring `r` from `N_star`."""
         gamma = StarobinskyPotential.gamma
         return 32 / (2*N_star*gamma + np.sqrt(2))**2
 
     @staticmethod
     def sr_r2Nstar(r):
-        """Slow-roll approximation for inferring `N_star` from `r`"""
+        """Slow-roll approximation for inferring `N_star` from `r`."""
         gamma = StarobinskyPotential.gamma
         return np.sqrt(2) * (4 - np.sqrt(r)) / (2 * gamma * np.sqrt(r))
 
@@ -688,7 +688,7 @@ class NaturalPotential(InflationaryPotential):
 
     @staticmethod
     def sr_ns2Nstar(n_s, **pot_kwargs):
-        """Slow-roll approximation for inferring `N_star` from `n_s`"""
+        """Slow-roll approximation for inferring `N_star` from `n_s`."""
         phi0 = pot_kwargs.pop('phi0')
         f = phi0 / pi
         return f**2 * np.log(f**2 * (2*f**2*(1-n_s)+(1-n_s)+2) / ((2*f**2+1) * (f**2*(1-n_s)-1)))
@@ -702,7 +702,7 @@ class NaturalPotential(InflationaryPotential):
 
     @staticmethod
     def sr_r2Nstar(r, **pot_kwargs):
-        """Slow-roll approximation for inferring `N_star` from `r`"""
+        """Slow-roll approximation for inferring `N_star` from `r`."""
         phi0 = pot_kwargs.pop('phi0')
         f = phi0 / pi
         return f**2 * np.log((2 * f**2 * r + 16) / (r * (2 * f**2 + 1)))

--- a/primpy/potentials.py
+++ b/primpy/potentials.py
@@ -461,7 +461,6 @@ class QuarticPotential(MonomialPotential):
     def __init__(self, **pot_kwargs):
         super().__init__(p=4, **pot_kwargs)
 
-
     @staticmethod
     def sr_Nstar2ns(N_star, **pot_kwargs):
         return MonomialPotential.sr_Nstar2ns(N_star=N_star, p=4)
@@ -477,6 +476,7 @@ class QuarticPotential(MonomialPotential):
     @staticmethod
     def sr_r2Nstar(r, **pot_kwargs):
         return MonomialPotential.sr_r2Nstar(r=r, p=4)
+
     @staticmethod
     def sr_As2Lambda(A_s, phi_star, N_star, **pot_kwargs):
         """Get potential amplitude `Lambda` from PPS amplitude `A_s`.

--- a/primpy/potentials.py
+++ b/primpy/potentials.py
@@ -156,7 +156,7 @@ class MonomialPotential(InflationaryPotential):
 
     def __init__(self, **pot_kwargs):
         self.p = pot_kwargs.pop('p')
-        super(MonomialPotential, self).__init__(**pot_kwargs)
+        super().__init__(**pot_kwargs)
 
     def V(self, phi):
         """`V(phi) = Lambda**4 * phi**p`."""
@@ -177,6 +177,30 @@ class MonomialPotential(InflationaryPotential):
     def inv_V(self, V):
         """`phi(V) = (V / Lambda**4)**(1/p)`."""
         return (V / self.Lambda**4)**(1/self.p)
+
+    @staticmethod
+    def sr_Nstar2ns(N_star, **pot_kwargs):
+        """Slow-roll approximation for inferring `n_s` from `N_star`"""
+        p = pot_kwargs.pop('p')
+        return 1 - p / (2 * N_star) - 1 / N_star
+
+    @staticmethod
+    def sr_ns2Nstar(n_s, **pot_kwargs):
+        """Slow-roll approximation for inferring `N_star` from `n_s`"""
+        p = pot_kwargs.pop('p')
+        return (2 + p) / (2 * (1 - n_s))
+
+    @staticmethod
+    def sr_Nstar2r(N_star, **pot_kwargs):
+        """Slow-roll approximation for inferring `r` from `N_star`"""
+        p = pot_kwargs.pop('p')
+        return 16 * p / (4 * N_star + p)
+
+    @staticmethod
+    def sr_r2Nstar(r, **pot_kwargs):
+        """Slow-roll approximation for inferring `N_star` from `r`"""
+        p = pot_kwargs.pop('p')
+        return p * (16 - r) / (4 * r)
 
     @staticmethod
     def sr_As2Lambda(A_s, phi_star, N_star, **pot_kwargs):
@@ -228,10 +252,26 @@ class LinearPotential(MonomialPotential):
     perturbation_ic = (1, 0, 0, 1)
 
     def __init__(self, **pot_kwargs):
-        super(LinearPotential, self).__init__(p=1, **pot_kwargs)
+        super().__init__(p=1, **pot_kwargs)
 
-    @classmethod
-    def sr_As2Lambda(cls, A_s, phi_star, N_star, **pot_kwargs):
+    @staticmethod
+    def sr_Nstar2ns(N_star, **pot_params):
+        return MonomialPotential.sr_Nstar2ns(N_star=N_star, p=1)
+
+    @staticmethod
+    def sr_ns2Nstar(n_s, **pot_params):
+        return MonomialPotential.sr_ns2Nstar(n_s=n_s, p=1)
+
+    @staticmethod
+    def sr_Nstar2r(N_star, **pot_params):
+        return MonomialPotential.sr_Nstar2r(N_star=N_star, p=1)
+
+    @staticmethod
+    def sr_r2Nstar(r, **pot_params):
+        return MonomialPotential.sr_r2Nstar(r=r, p=1)
+
+    @staticmethod
+    def sr_As2Lambda(A_s, phi_star, N_star, **pot_kwargs):
         """Get potential amplitude `Lambda` from PPS amplitude `A_s`.
 
         Find the inflaton amplitude `Lambda` (4th root of potential amplitude)
@@ -259,11 +299,11 @@ class LinearPotential(MonomialPotential):
                 from horizon crossing till the end of inflation.
 
         """
-        return super(LinearPotential, cls).sr_As2Lambda(A_s, phi_star, N_star, p=1)
+        return MonomialPotential.sr_As2Lambda(A_s, phi_star, N_star, p=1)
 
 
-class QuadraticPotential(InflationaryPotential):
-    """Quadratic potential: `V(phi) = 0.5 * m**2 * phi**2`."""
+class QuadraticPotential(MonomialPotential):
+    """Quadratic potential: `V(phi) = Lambda**4 * phi**2`."""
 
     tag = 'mn2'
     name = 'QuadraticPotential'
@@ -272,31 +312,44 @@ class QuadraticPotential(InflationaryPotential):
 
     def __init__(self, **pot_kwargs):
         if 'mass' in pot_kwargs:
-            if 'Lambda' in pot_kwargs:
-                raise Exception("'mass' and 'Lambda' must not be specified simultaneously.")
-            pot_kwargs['Lambda'] = np.sqrt(pot_kwargs.pop('mass'))
-        super(QuadraticPotential, self).__init__(**pot_kwargs)
-        self.mass = self.Lambda**2
+            raise ValueError("'mass' was dropped use 'Lambda' instead: Lambda**4=mass**2")
+        super().__init__(p=2, **pot_kwargs)
 
     def V(self, phi):
-        """`V(phi) = 0.5 * m**2 * phi**2`."""
-        return self.mass**2 * phi**2 / 2
+        """`V(phi) = Lambda**4 * phi**2`."""
+        return self.Lambda**4 * phi**2
 
     def dV(self, phi):
-        """`V'(phi) = m**2 phi`."""
-        return self.mass**2 * phi
+        """`V'(phi) = 2 * Lambda**4 * phi`."""
+        return 2 * self.Lambda**4 * phi
 
     def d2V(self, phi):
-        """`V''(phi) = m**2`."""
-        return self.mass**2
+        """`V''(phi) = 2 * Lambda**4`."""
+        return 2 * self.Lambda**4
 
     def d3V(self, phi):
         """`V'''(phi) = 0`."""
         return 0
 
     def inv_V(self, V):
-        """`phi(V) = sqrt(2 * V) / m`."""
-        return np.sqrt(2 * V) / self.mass
+        """`phi(V) = sqrt(V) / Lambda**2`."""
+        return np.sqrt(V) / self.Lambda**2
+
+    @staticmethod
+    def sr_Nstar2ns(N_star, **pot_kwargs):
+        return MonomialPotential.sr_Nstar2ns(N_star=N_star, p=2)
+
+    @staticmethod
+    def sr_ns2Nstar(n_s, **pot_kwargs):
+        return MonomialPotential.sr_ns2Nstar(n_s=n_s, p=2)
+
+    @staticmethod
+    def sr_Nstar2r(N_star, **pot_kwargs):
+        return MonomialPotential.sr_Nstar2r(N_star=N_star, p=2)
+
+    @staticmethod
+    def sr_r2Nstar(r, **pot_kwargs):
+        return MonomialPotential.sr_r2Nstar(r=r, p=2)
 
     @staticmethod
     def sr_As2Lambda(A_s, phi_star, N_star, **pot_kwargs):
@@ -347,10 +400,26 @@ class CubicPotential(MonomialPotential):
     perturbation_ic = (1, 0, 0, 1)
 
     def __init__(self, **pot_kwargs):
-        super(CubicPotential, self).__init__(p=3, **pot_kwargs)
+        super().__init__(p=3, **pot_kwargs)
 
-    @classmethod
-    def sr_As2Lambda(cls, A_s, phi_star, N_star, **pot_kwargs):
+    @staticmethod
+    def sr_Nstar2ns(N_star, **pot_kwargs):
+        return MonomialPotential.sr_Nstar2ns(N_star=N_star, p=3)
+
+    @staticmethod
+    def sr_ns2Nstar(n_s, **pot_kwargs):
+        return MonomialPotential.sr_ns2Nstar(n_s=n_s, p=3)
+
+    @staticmethod
+    def sr_Nstar2r(N_star, **pot_kwargs):
+        return MonomialPotential.sr_Nstar2r(N_star=N_star, p=3)
+
+    @staticmethod
+    def sr_r2Nstar(r, **pot_kwargs):
+        return MonomialPotential.sr_r2Nstar(r=r, p=3)
+
+    @staticmethod
+    def sr_As2Lambda(A_s, phi_star, N_star, **pot_kwargs):
         """Get potential amplitude `Lambda` from PPS amplitude `A_s`.
 
         Find the inflaton amplitude `Lambda` (4th root of potential amplitude)
@@ -378,7 +447,7 @@ class CubicPotential(MonomialPotential):
                 from horizon crossing till the end of inflation.
 
         """
-        return super(CubicPotential, cls).sr_As2Lambda(A_s, phi_star, N_star, p=3)
+        return MonomialPotential.sr_As2Lambda(A_s, phi_star, N_star, p=3)
 
 
 class QuarticPotential(MonomialPotential):
@@ -390,10 +459,26 @@ class QuarticPotential(MonomialPotential):
     perturbation_ic = (1, 0, 0, 1)
 
     def __init__(self, **pot_kwargs):
-        super(QuarticPotential, self).__init__(p=4, **pot_kwargs)
+        super().__init__(p=4, **pot_kwargs)
 
-    @classmethod
-    def sr_As2Lambda(cls, A_s, phi_star, N_star, **pot_kwargs):
+
+    @staticmethod
+    def sr_Nstar2ns(N_star, **pot_kwargs):
+        return MonomialPotential.sr_Nstar2ns(N_star=N_star, p=4)
+
+    @staticmethod
+    def sr_ns2Nstar(n_s, **pot_kwargs):
+        return MonomialPotential.sr_ns2Nstar(n_s=n_s, p=4)
+
+    @staticmethod
+    def sr_Nstar2r(N_star, **pot_kwargs):
+        return MonomialPotential.sr_Nstar2r(N_star=N_star, p=4)
+
+    @staticmethod
+    def sr_r2Nstar(r, **pot_kwargs):
+        return MonomialPotential.sr_r2Nstar(r=r, p=4)
+    @staticmethod
+    def sr_As2Lambda(A_s, phi_star, N_star, **pot_kwargs):
         """Get potential amplitude `Lambda` from PPS amplitude `A_s`.
 
         Find the inflaton amplitude `Lambda` (4th root of potential amplitude)
@@ -421,7 +506,7 @@ class QuarticPotential(MonomialPotential):
                 from horizon crossing till the end of inflation.
 
         """
-        return super(QuarticPotential, cls).sr_As2Lambda(A_s, phi_star, N_star, p=4)
+        return MonomialPotential.sr_As2Lambda(A_s, phi_star, N_star, p=4)
 
 
 class StarobinskyPotential(InflationaryPotential):
@@ -434,7 +519,7 @@ class StarobinskyPotential(InflationaryPotential):
     perturbation_ic = (1-2, 0, 0, 1e-8)
 
     def __init__(self, **pot_kwargs):
-        super(StarobinskyPotential, self).__init__(**pot_kwargs)
+        super().__init__(**pot_kwargs)
 
     def V(self, phi):
         """`V(phi) = Lambda**4 * (1 - exp(-sqrt(2/3) * phi))**2`."""
@@ -458,6 +543,34 @@ class StarobinskyPotential(InflationaryPotential):
     def inv_V(self, V):
         """`phi(V) = -np.log(1 - np.sqrt(V) / Lambda**2) / gamma`."""
         return -np.log(1 - np.sqrt(V) / self.Lambda**2) / StarobinskyPotential.gamma
+
+    @staticmethod
+    def sr_Nstar2ns(N_star):
+        """Slow-roll approximation for inferring `n_s` from `N_star`"""
+        gamma = StarobinskyPotential.gamma
+        num = 2 * N_star * gamma**2 + np.sqrt(2) * gamma + 2
+        den = N_star * gamma * (N_star * gamma + np.sqrt(2))
+        return 1 - num / den
+
+    @staticmethod
+    def sr_ns2Nstar(n_s):
+        """Slow-roll approximation for inferring `N_star` from `n_s`"""
+        gamma = StarobinskyPotential.gamma
+        num = 2*gamma - np.sqrt(2) * (1-n_s) + np.sqrt(2*(1-n_s)**2 + 8*(1-n_s) + 4*gamma**2)
+        den = 2 * gamma * (1-n_s)
+        return num / den
+
+    @staticmethod
+    def sr_Nstar2r(N_star):
+        """Slow-roll approximation for inferring `r` from `N_star`"""
+        gamma = StarobinskyPotential.gamma
+        return 32 / (2*N_star*gamma + np.sqrt(2))**2
+
+    @staticmethod
+    def sr_r2Nstar(r):
+        """Slow-roll approximation for inferring `N_star` from `r`"""
+        gamma = StarobinskyPotential.gamma
+        return np.sqrt(2) * (4 - np.sqrt(r)) / (2 * gamma * np.sqrt(r))
 
     @staticmethod
     def phi2efolds(phi):
@@ -542,7 +655,7 @@ class NaturalPotential(InflationaryPotential):
 
     def __init__(self, **pot_kwargs):
         self.phi0 = pot_kwargs.pop('phi0')
-        super(NaturalPotential, self).__init__(**pot_kwargs)
+        super().__init__(**pot_kwargs)
 
     def V(self, phi):
         """`V(phi) = Lambda**4 * (1 - cos(pi*phi/phi0))`."""
@@ -565,23 +678,37 @@ class NaturalPotential(InflationaryPotential):
         return np.arccos(1 - 2 * V / self.Lambda**4) * self.phi0 / pi
 
     @staticmethod
-    def sr_n_s(N_star, **pot_kwargs):
+    def sr_Nstar2ns(N_star, **pot_kwargs):
         """Slow-roll approximation for the spectral index `n_s`."""
         phi0 = pot_kwargs.pop('phi0')
         f = phi0 / pi
-        numerator = 1 + 4 * f**2
-        denominator = (-1 + np.exp(N_star / f**2)) * (1 + 2 * f**2)
-        return 1 - 1 / f**2 * (1 + numerator / denominator)
+        num = (2 * f**2 + (2 * f**2 + 1) * np.exp(N_star / f**2))
+        den = (f**2 * (2 * f**2 + 1) * (np.exp(N_star / f**2) - 1))
+        return 1 - num / den
 
     @staticmethod
-    def sr_r(N_star, **pot_kwargs):
+    def sr_ns2Nstar(n_s, **pot_kwargs):
+        """Slow-roll approximation for inferring `N_star` from `n_s`"""
+        phi0 = pot_kwargs.pop('phi0')
+        f = phi0 / pi
+        return f**2 * np.log(f**2 * (2*f**2*(1-n_s)+(1-n_s)+2) / ((2*f**2+1) * (f**2*(1-n_s)-1)))
+
+    @staticmethod
+    def sr_Nstar2r(N_star, **pot_kwargs):
         """Slow-roll approximation for the tensor-to-scalar ratio `r`."""
         phi0 = pot_kwargs.pop('phi0')
         f = phi0 / pi
-        return 16 / (-2 * f**2 + np.exp(N_star / f**2) * (1 + 2 * f**2))
+        return 16 / (-2 * f**2 + (2 * f**2 + 1) * np.exp(N_star / f**2))
 
-    @classmethod
-    def phi2efolds(cls, phi, phi0):
+    @staticmethod
+    def sr_r2Nstar(r, **pot_kwargs):
+        """Slow-roll approximation for inferring `N_star` from `r`"""
+        phi0 = pot_kwargs.pop('phi0')
+        f = phi0 / pi
+        return f**2 * np.log((2 * f**2 * r + 16) / (r * (2 * f**2 + 1)))
+
+    @staticmethod
+    def phi2efolds(phi, phi0):
         """Get e-folds `N` from inflaton `phi`.
 
         Find the number of e-folds `N` till end of inflation from inflaton `phi`
@@ -667,7 +794,7 @@ class DoubleWellPotential(InflationaryPotential):
     def __init__(self, **pot_kwargs):
         self.phi0 = pot_kwargs.pop('phi0')
         self.p = pot_kwargs.pop('p')
-        super(DoubleWellPotential, self).__init__(**pot_kwargs)
+        super().__init__(**pot_kwargs)
         self.prefactor = 2 * self.p * self.Lambda**4
 
     def V(self, phi):
@@ -732,7 +859,7 @@ class DoubleWell2Potential(DoubleWellPotential):
     perturbation_ic = (1e-1, 0, 0, 1e-5)
 
     def __init__(self, **pot_kwargs):
-        super(DoubleWell2Potential, self).__init__(p=2, **pot_kwargs)
+        super().__init__(p=2, **pot_kwargs)
 
     @staticmethod
     def phi2efolds(phi_shifted, phi0):
@@ -823,7 +950,7 @@ class DoubleWell4Potential(DoubleWellPotential):
     perturbation_ic = (1e-1, 0, 0, 1e-5)
 
     def __init__(self, **pot_kwargs):
-        super(DoubleWell4Potential, self).__init__(p=4, **pot_kwargs)
+        super().__init__(p=4, **pot_kwargs)
 
     @staticmethod
     def phi_end_squared(phi0):

--- a/tests/test_efolds_inflation.py
+++ b/tests/test_efolds_inflation.py
@@ -14,8 +14,9 @@ def test_basic_methods(K):
     y0 = np.zeros(len(eq.idx))
     assert eq.H2(x=0, y=y0) == -K
     y1 = np.ones(len(eq.idx))
-    H2 = (1 - 6 * K * np.exp(-2)) / 5
+    V = 1
+    H2 = (2 * V - 6 * K * np.exp(-2)) / 5
     assert eq.H2(x=1, y=y1) == H2
     assert eq.H(x=1, y=y1) == np.sqrt(H2)
-    assert eq.w(x=1, y=y1) == (H2 - 1) / (H2 + 1)
-    assert eq.inflating(x=1, y=y1) == 1 / 2 - H2
+    assert eq.w(x=1, y=y1) == (H2/2 - V) / (H2/2 + V)
+    assert eq.inflating(x=1, y=y1) == V - H2

--- a/tests/test_equations.py
+++ b/tests/test_equations.py
@@ -20,7 +20,7 @@ def test_not_implemented_errors():
 
 @pytest.mark.filterwarnings("ignore:invalid value encountered in sqrt:RuntimeWarning")
 @pytest.mark.parametrize('K', [-1, 0, +1])
-@pytest.mark.parametrize('phi_i, pot', [(17, QuadraticPotential(mass=6e-6)),
+@pytest.mark.parametrize('phi_i, pot', [(17, QuadraticPotential(Lambda=np.sqrt(6e-6))),
                                         (6, StarobinskyPotential(Lambda=5e-2))])
 def test_equations_sol_ordering_after_postprocessing(K, phi_i, pot):
     t_i = 7e4

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -20,7 +20,7 @@ def test_not_implemented_errors():
 
 @pytest.mark.parametrize('K', [-1, 0, +1])
 def test_UntilTEvent(K):
-    pot = QuadraticPotential(Lambda=np.sqrt(6e-6))
+    pot = QuadraticPotential(Lambda=0.0025)
     t_i = 7e4
     N_i = 10
     phi_i = 17
@@ -37,7 +37,7 @@ def test_UntilTEvent(K):
 @pytest.mark.parametrize('K', [-1, 0, +1])
 @pytest.mark.parametrize('Eq', [InflationEquationsT, InflationEquationsN])
 def test_UntilNEvent(K, Eq):
-    pot = QuadraticPotential(Lambda=np.sqrt(6e-6))
+    pot = QuadraticPotential(Lambda=0.0025)
     t_i = 7e4
     N_i = 10
     phi_i = 17
@@ -51,7 +51,7 @@ def test_UntilNEvent(K, Eq):
 
 
 @pytest.mark.parametrize('K', [-1, 0, +1])
-@pytest.mark.parametrize('Lambda', [1, np.sqrt(6e-6)])
+@pytest.mark.parametrize('Lambda', [1, 0.0025])
 @pytest.mark.parametrize('Eq', [InflationEquationsT, InflationEquationsN])
 def test_InflationEvent(K, Lambda, Eq):
     t_i = 7e4
@@ -73,7 +73,7 @@ def test_InflationEvent(K, Lambda, Eq):
 @pytest.mark.parametrize('K', [-1, 0, +1])
 @pytest.mark.parametrize('Eq', [InflationEquationsT, InflationEquationsN])
 def test_AfterInflationEndEvent(K, Eq):
-    pot = QuadraticPotential(Lambda=np.sqrt(6e-6))
+    pot = QuadraticPotential(Lambda=0.0025)
     t_i = 7e4
     N_i = 10
     phi_i = 17
@@ -96,7 +96,7 @@ def test_AfterInflationEndEvent(K, Eq):
 @pytest.mark.parametrize('K', [-1, 0, +1])
 @pytest.mark.parametrize('Eq', [InflationEquationsT, InflationEquationsN])
 def test_Phi0Event(K, Eq):
-    pot = QuadraticPotential(Lambda=np.sqrt(6e-6))
+    pot = QuadraticPotential(Lambda=0.0025)
     t_i = 7e4
     N_i = 12
     phi_i = 17

--- a/tests/test_initialconditions.py
+++ b/tests/test_initialconditions.py
@@ -35,7 +35,7 @@ def basic_ic_asserts(y0, ic, K, pot, N_i, Omega_Ki, phi_i, t_i):
     assert ic.equations.potential.d3V(phi_i) == pot.d3V(phi_i)
 
 
-@pytest.mark.parametrize('pot', [QuadraticPotential(Lambda=np.sqrt(6e-6)),
+@pytest.mark.parametrize('pot', [QuadraticPotential(Lambda=0.0025),
                                  StarobinskyPotential(Lambda=5e-2)])
 @pytest.mark.parametrize('K', [-1, 0, +1])
 @pytest.mark.parametrize('t_i, Eq', [(1e4, InflationEquationsT), (None, InflationEquationsN)])
@@ -102,7 +102,7 @@ def test_SlowRollIC_failures():
         ic(y0)
 
 
-@pytest.mark.parametrize('pot', [QuadraticPotential(Lambda=np.sqrt(6e-6)),
+@pytest.mark.parametrize('pot', [QuadraticPotential(Lambda=0.0025),
                                  StarobinskyPotential(Lambda=5e-2)])
 @pytest.mark.parametrize('K', [-1, 0, +1])
 @pytest.mark.parametrize('t_i, Eq', [(1e4, InflationEquationsT), (None, InflationEquationsN)])
@@ -151,7 +151,7 @@ def test_InflationStartIC(pot, K, t_i, Eq):
 def test_ISIC_Nt_Ni(K, t_i, Eq):
     N_i = 11
     N_tot = 60
-    pot = QuadraticPotential(Lambda=np.sqrt(6e-6))
+    pot = QuadraticPotential(Lambda=0.0025)
     eq = Eq(K=K, potential=pot)
     ic = ISIC_Nt(equations=eq, N_i=N_i, N_tot=N_tot, t_i=t_i, phi_i_bracket=[3, 30])
     y0 = np.zeros(len(ic.equations.idx))
@@ -179,7 +179,7 @@ def test_ISIC_Nt_Ni(K, t_i, Eq):
 def test_ISIC_Nt_Oi(K, abs_Omega_Ki, t_i, Eq):
     Omega_Ki = -K * abs_Omega_Ki
     N_tot = 60
-    pot = QuadraticPotential(Lambda=np.sqrt(6e-6))
+    pot = QuadraticPotential(Lambda=0.0025)
     eq = Eq(K=K, potential=pot)
     if Omega_Ki >= 1:
         with pytest.raises(InflationStartError):
@@ -208,7 +208,7 @@ def test_ISIC_Nt_Oi(K, abs_Omega_Ki, t_i, Eq):
 @pytest.mark.parametrize('K', [-1, +1])
 @pytest.mark.parametrize('t_i, Eq', [(1e4, InflationEquationsT), (None, InflationEquationsN)])
 def test_ISIC_NsOk(K, t_i, Eq):
-    pot = QuadraticPotential(Lambda=np.sqrt(6e-6))
+    pot = QuadraticPotential(Lambda=0.0025)
     N_star = 55
     h = 0.7
 

--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -144,7 +144,7 @@ def test_monomial_slow_roll(p, N_star):
 def test_specific_monomial_slow_roll(Pot, p, N_star):
     n_s = Pot.sr_Nstar2ns(N_star=N_star)
     assert 0.8 < n_s < 1
-    assert n_s == 1 - p / (2 *N_star) - 1 / N_star
+    assert n_s == 1 - p / (2 * N_star) - 1 / N_star
     assert Pot.sr_ns2Nstar(n_s=n_s) == pytest.approx(N_star)
 
     r = Pot.sr_Nstar2r(N_star=N_star)

--- a/tests/test_time_inflation.py
+++ b/tests/test_time_inflation.py
@@ -14,7 +14,9 @@ def test_basic_methods(K):
     y0 = np.zeros(len(eq.idx))
     assert eq.H2(x=0, y=y0) == -K
     y1 = np.ones(len(eq.idx))
-    assert eq.H2(x=1, y=y1) == 1 / 3 - K * np.exp(-2)
-    assert eq.H(x=1, y=y1) == np.sqrt(1 / 3 - K * np.exp(-2))
-    assert eq.w(x=1, y=y1) == 0
-    assert eq.inflating(x=1, y=y1) == -0.5
+    V = 1
+    H2 = (1 / 2 + V) / 3 - K * np.exp(-2)
+    assert eq.H2(x=1, y=y1) == H2
+    assert eq.H(x=1, y=y1) == np.sqrt(H2)
+    assert eq.w(x=1, y=y1) == (1/2 - V) / (1/2 + V)
+    assert eq.inflating(x=1, y=y1) == V - 1


### PR DESCRIPTION
* Make `QuadraticPotential` consistent with `MonomialPotential(p=2)`, i.e. drop the factor of one half (internal consistency is more important than matching old theory formulations).
  - Drop the `mass` parameter and use `Lambda` as for the other potentials.
  - Adapt tests accordingly (this required changing some hard coded values in the tests...), tried to make things more explicit at the same time. Using `Lambda=0.0025` instead of `mass=6e-6` in most places (note that the factor of one half needed folding into Lambda).
* add slow-roll approximate conversions for Monomial, Starobinsky, and Natural potentials:
  - from `N_star` to `n_s`
  - from `n_s` to `N_star`
  - from `N_star` to `r`
  - from `r` to `N_star`
  - add tests for all these methods


# Checklist:

- [x] I have performed a self-review of my own code.
- [x] My code is PEP8 compliant (`flake8 --max-line-length 99 primpy tests`).
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `anesthetic/__version__.py`.
