### PR TITLE
Optionally start perturbation integration from fraction of horizon size

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.6.0
+:Version: 2.7.0
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 """:mod:`primpy.__version__`: version file for primpy."""
 
-__version__ = '2.6.0'
+__version__ = '2.7.0'

--- a/primpy/efolds/perturbations.py
+++ b/primpy/efolds/perturbations.py
@@ -48,12 +48,12 @@ class ScalarModeN(ScalarMode):
 
         """
         K = self.background.K
-        a2 = np.exp(2 * self.background.N[:self.idx_end])
-        H = self.background.H[:self.idx_end]
-        dphidN = self.background.dphidN[:self.idx_end]
+        a2 = np.exp(2 * self.background.N[self.idx_beg:self.idx_end+1])
+        H = self.background.H[self.idx_beg:self.idx_end+1]
+        dphidN = self.background.dphidN[self.idx_beg:self.idx_end+1]
         H2 = H**2
-        dV = self.background.potential.dV(self.background.phi[:self.idx_end])
-        Omega_K = self.background.Omega_K[:self.idx_end]
+        dV = self.background.potential.dV(self.background.phi[self.idx_beg:self.idx_end+1])
+        Omega_K = self.background.Omega_K[self.idx_beg:self.idx_end+1]
 
         kappa2 = self.k**2 + self.k * K * (K + 1) - 3 * K
         epsilon = dphidN**2 / 2
@@ -68,9 +68,9 @@ class ScalarModeN(ScalarMode):
 
     def get_vacuum_ic_RST(self):
         """Get initial conditions for scalar modes for RST vacuum w.r.t. e-folds `N`."""
-        a_i = np.exp(self.background.N[0])
-        H_i = self.background.H[0]
-        z_i = a_i * self.background.dphidN[0]
+        a_i = np.exp(self.background.N[self.idx_beg])
+        H_i = self.background.H[self.idx_beg]
+        z_i = a_i * self.background.dphidN[self.idx_beg]
         Rk_i = 1 / np.sqrt(2 * self.k) / z_i
         dRk_i = -1j * self.k / (a_i * H_i) * Rk_i
         return Rk_i, dRk_i
@@ -96,9 +96,9 @@ class TensorModeN(TensorMode):
 
         """
         K = self.background.K
-        N = self.background.N[:self.idx_end]
-        H2 = self.background.H[:self.idx_end]**2
-        dphidN = self.background.dphidN[:self.idx_end]
+        N = self.background.N[self.idx_beg:self.idx_end+1]
+        H2 = self.background.H[self.idx_beg:self.idx_end+1]**2
+        dphidN = self.background.dphidN[self.idx_beg:self.idx_end+1]
         frequency2 = (self.k**2 + self.k * K * (K + 1) + 2 * K) * np.exp(-2 * N) / H2
         damping2 = 3 - dphidN**2 / 2 + K * np.exp(-2 * N) / H2
         if np.all(frequency2 > 0):
@@ -108,8 +108,8 @@ class TensorModeN(TensorMode):
 
     def get_vacuum_ic_RST(self):
         """Get initial conditions for tensor modes for RST vacuum w.r.t. e-folds `N`."""
-        a_i = np.exp(self.background.N[0])
-        H_i = self.background.H[0]
+        a_i = np.exp(self.background.N[self.idx_beg])
+        H_i = self.background.H[self.idx_beg]
         hk_i = 2 / np.sqrt(2 * self.k) / a_i
         dhk_i = -1j * self.k / (a_i * H_i) * hk_i
         return hk_i, dhk_i

--- a/primpy/inflation.py
+++ b/primpy/inflation.py
@@ -209,7 +209,7 @@ class InflationEquations(Equations, ABC):
 
             logk, indices = np.unique(sol.logk, return_index=True)
             spline_order = interp1d_kwargs.pop('k', 3)
-            extrapolate = interp1d_kwargs.pop('ext', 'zeros')
+            extrapolate = interp1d_kwargs.pop('ext', 'const')
             sol.logk2logP_s = InterpolatedUnivariateSpline(logk,
                                                            np.log(sol.P_scalar_approx[indices]),
                                                            k=spline_order, ext=extrapolate,

--- a/primpy/inflation.py
+++ b/primpy/inflation.py
@@ -174,7 +174,7 @@ class InflationEquations(Equations, ABC):
             logaH = sol.logaH[sol.inflation_mask]
             sol.logk = np.log(K_STAR) + logaH - sol.logaH_star
             sol.k_iMpc = np.exp(sol.logk)
-            sol.k_comoving = sol.k_iMpc * sol.a0_Mpc
+            sol.k_comoving = np.exp(logaH)
 
             derive_approx_power(**interp1d_kwargs)
 
@@ -186,6 +186,7 @@ class InflationEquations(Equations, ABC):
             N = sol.N[sol.inflation_mask]
             logaH = sol.logaH[sol.inflation_mask]
             sol.logk = logaH - np.log(sol.a0_Mpc)
+            sol.logaH_star = np.log(K_STAR * sol.a0_Mpc)
             if np.log(K_STAR) < np.min(sol.logk) or np.log(K_STAR) > np.max(sol.logk):
                 sol.N_cross = np.nan
             else:

--- a/primpy/oscode_solver.py
+++ b/primpy/oscode_solver.py
@@ -92,7 +92,7 @@ def solve_oscode(background, k, **kwargs):
             idx_beg = 0 if idx_beg.size == 0 else idx_beg[-1]
         idx_end = np.argwhere(b.logaH - np.log(ki) > np.log(fac_end)).ravel()[0]
         # set minimum for idx_end, needed e.g. in KD for superhorizon modes:
-        idx_end = idx_end if idx_end - idx_beg > 1000 else idx_beg + 1000
+        idx_end = idx_end if idx_end - idx_beg > b.logaH.size//20 else idx_beg + b.logaH.size//20
         if b.independent_variable == 't':
             p = PerturbationT(background=b, k=ki, idx_beg=idx_beg, idx_end=idx_end, **kwargs)
         elif b.independent_variable == 'N':

--- a/primpy/oscode_solver.py
+++ b/primpy/oscode_solver.py
@@ -84,7 +84,7 @@ def solve_oscode(background, k, **kwargs):
     PPS = PrimordialPowerSpectrum(background=b, k=k, **kwargs)
     # stop integration sufficiently after mode has crossed the horizon (lazy for loop):
     for i, ki in enumerate(k):
-        if fac_beg==0:
+        if fac_beg == 0:
             idx_beg = 0
         else:
             idx_beg = np.argwhere(np.log(ki) - b.logaH > np.log(fac_beg)).ravel()

--- a/primpy/perturbations.py
+++ b/primpy/perturbations.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 from scipy.integrate import solve_ivp
 from primpy.units import pi
+from primpy.parameters import K_STAR
 from primpy.equations import Equations
 
 
@@ -13,7 +14,7 @@ class PrimordialPowerSpectrum(object):
     def __init__(self, background, k, **kwargs):
         self.background = background
         self.k = k
-        self.k_iMpc = k / background.a0_Mpc
+        self.k_iMpc = k * K_STAR / np.exp(background.logaH_star)
         vacuum = kwargs.pop('vacuum', ('RST',))
         for vac in vacuum:
             setattr(self, 'P_s_%s' % vac, np.full_like(k, np.nan, dtype=float))

--- a/primpy/perturbations.py
+++ b/primpy/perturbations.py
@@ -80,6 +80,7 @@ class Mode(Equations, ABC):
 
     def __init__(self, background, k, **kwargs):
         super(Mode, self).__init__()
+        self.idx_beg = kwargs.get('idx_beg', 0)
         self.idx_end = kwargs.get('idx_end', background.x.size)
         self.background = background
         self.k = k

--- a/primpy/time/perturbations.py
+++ b/primpy/time/perturbations.py
@@ -47,10 +47,10 @@ class ScalarModeT(ScalarMode):
 
         """
         K = self.background.K
-        N = self.background.N[:self.idx_end]
-        dphidt = self.background.dphidt[:self.idx_end]
-        H = self.background.H[:self.idx_end]
-        dV = self.background.potential.dV(self.background.phi[:self.idx_end])
+        N = self.background.N[self.idx_beg:self.idx_end+1]
+        dphidt = self.background.dphidt[self.idx_beg:self.idx_end+1]
+        H = self.background.H[self.idx_beg:self.idx_end+1]
+        dV = self.background.potential.dV(self.background.phi[self.idx_beg:self.idx_end+1])
 
         kappa2 = self.k**2 + self.k * K * (K + 1) - 3 * K
         shared = 2 * kappa2 / (kappa2 + K * dphidt**2 / (2 * H**2))
@@ -65,9 +65,9 @@ class ScalarModeT(ScalarMode):
 
     def get_vacuum_ic_RST(self):
         """Get initial conditions for scalar modes for RST vacuum w.r.t. cosmic time `t`."""
-        a_i = np.exp(self.background.N[0])
-        dphidt_i = self.background.dphidt[0]
-        H_i = self.background.H[0]
+        a_i = np.exp(self.background.N[self.idx_beg])
+        dphidt_i = self.background.dphidt[self.idx_beg]
+        H_i = self.background.H[self.idx_beg]
         z_i = a_i * dphidt_i / H_i
         Rk_i = 1 / np.sqrt(2 * self.k) / z_i
         dRk_i = -1j * self.k / a_i * Rk_i
@@ -94,9 +94,9 @@ class TensorModeT(TensorMode):
 
         """
         K = self.background.K
-        N = self.background.N[: self.idx_end]
+        N = self.background.N[self.idx_beg:self.idx_end+1]
         frequency2 = (self.k**2 + self.k * K * (K + 1) + 2 * K) * np.exp(-2 * N)
-        damping2 = 3 * self.background.H[: self.idx_end]
+        damping2 = 3 * self.background.H[self.idx_beg:self.idx_end+1]
         if np.all(frequency2 > 0):
             return np.sqrt(frequency2), damping2 / 2
         else:
@@ -104,7 +104,7 @@ class TensorModeT(TensorMode):
 
     def get_vacuum_ic_RST(self):
         """Get initial conditions for tensor modes for RST vacuum w.r.t. cosmic time `t`."""
-        a_i = np.exp(self.background.N[0])
+        a_i = np.exp(self.background.N[self.idx_beg])
         hk_i = 2 / np.sqrt(2 * self.k) / a_i
         dhk_i = -1j * self.k / a_i * hk_i
         return hk_i, dhk_i

--- a/tests/test_perturbations.py
+++ b/tests/test_perturbations.py
@@ -25,7 +25,7 @@ def set_background_SR():
 
     eq_t = InflationEquationsT(K=0, potential=pot)
     eq_n = InflationEquationsN(K=0, potential=pot)
-    t_eval = np.logspace(np.log10(5e4), np.log10(4e6), int(5e4))
+    t_eval = np.logspace(np.log10(5e4), np.log10(2e7), int(1e5))
     ic_t = SlowRollIC(eq_t, N_i=N_i, phi_i=phi_i, t_i=t_eval[0])
     ic_n = SlowRollIC(eq_n, N_i=N_i, phi_i=phi_i, t_i=None)
     N_eval = np.linspace(ic_n.N_i, 70, int(1e5))
@@ -57,7 +57,7 @@ def test_set_background_SR():
 
 def test_perturbations_SR():
     bsrt, bsrn = set_background_SR()
-    ks_iMpc = np.logspace(-4, 1, 5 * 10 + 1)
+    ks_iMpc = np.logspace(np.log10(5e-4), np.log10(5e0), 4 * 10 + 1)
     logk_iMpc = np.log(ks_iMpc)
     ks_cont = ks_iMpc * bsrt.a0_Mpc
     pps_t = solve_oscode(background=bsrt, k=ks_cont, fac_beg=100, rtol=1e-5)
@@ -68,14 +68,20 @@ def test_perturbations_SR():
     assert np.isfinite(pps_n.P_t_RST).all()
 
     # time vs efolds
-    assert_allclose(pps_t.P_s_RST * 1e9, pps_n.P_s_RST * 1e9, rtol=1e-5, atol=1e-8)
-    assert_allclose(pps_t.P_t_RST * 1e9, pps_n.P_t_RST * 1e9, rtol=1e-5, atol=1e-8)
+    assert_allclose(pps_t.P_s_RST * 1e9, pps_n.P_s_RST * 1e9, rtol=1e-3, atol=1e-6)
+    assert_allclose(pps_t.P_t_RST * 1e9, pps_n.P_t_RST * 1e9, rtol=1e-3, atol=1e-6)
 
     # oscode vs background
-    assert_allclose(np.log(pps_t.P_s_RST), bsrt.logk2logP_s(logk_iMpc), rtol=1e-5, atol=1e-8)
-    assert_allclose(np.log(pps_t.P_t_RST), bsrt.logk2logP_t(logk_iMpc), rtol=1e-5, atol=1e-8)
-    assert_allclose(np.log(pps_n.P_s_RST), bsrn.logk2logP_s(logk_iMpc), rtol=1e-5, atol=1e-8)
-    assert_allclose(np.log(pps_n.P_t_RST), bsrn.logk2logP_t(logk_iMpc), rtol=1e-5, atol=1e-8)
+    As_t_oscode = pps_t.P_s_RST[ks_iMpc.size//2]
+    As_n_oscode = pps_n.P_s_RST[ks_iMpc.size//2]
+    assert As_t_oscode == approx(bsrt.A_s, rel=5e-2)
+    assert As_n_oscode == approx(bsrn.A_s, rel=5e-2)
+    offt = bsrt.A_s / As_t_oscode
+    offn = bsrn.A_s / As_n_oscode
+    assert_allclose(np.log(pps_t.P_s_RST*offt), bsrt.logk2logP_s(logk_iMpc), rtol=1e-3, atol=1e-6)
+    assert_allclose(np.log(pps_n.P_s_RST*offn), bsrn.logk2logP_s(logk_iMpc), rtol=1e-3, atol=1e-6)
+    assert_allclose(np.log(pps_t.P_t_RST), bsrt.logk2logP_t(logk_iMpc), rtol=1e-3, atol=1e-6)
+    assert_allclose(np.log(pps_n.P_t_RST), bsrn.logk2logP_t(logk_iMpc), rtol=1e-3, atol=1e-6)
 
 
 def set_background_IS(K, f_i, abs_Omega_K0):
@@ -87,7 +93,7 @@ def set_background_IS(K, f_i, abs_Omega_K0):
 
     eq_t = InflationEquationsT(K=K, potential=pot)
     eq_n = InflationEquationsN(K=K, potential=pot)
-    t_eval = np.logspace(np.log10(5e4), np.log10(4e6), int(5e4))
+    t_eval = np.logspace(np.log10(5e4), np.log10(4e6), int(1e5))
     ic_t = InflationStartIC(eq_t, phi_i=phi_i, Omega_Ki=Omega_Ki, t_i=t_eval[0])
     ic_n = InflationStartIC(eq_n, phi_i=phi_i, Omega_Ki=Omega_Ki, t_i=None)
     N_eval = np.linspace(ic_n.N_i, 70, int(1e5))

--- a/tests/test_perturbations.py
+++ b/tests/test_perturbations.py
@@ -64,7 +64,7 @@ def test_background_setup(K, f_i, abs_Omega_K0):
 @pytest.mark.parametrize('K', [-1, +1])
 @pytest.mark.parametrize('f_i', [10, 100])
 @pytest.mark.parametrize('abs_Omega_K0', [0.09, 0.009])
-@pytest.mark.parametrize('k_iMpc', np.logspace(-6, 0, 6 + 1))
+@pytest.mark.parametrize('k_iMpc', np.logspace(-5, 0, 5 + 1))
 def test_perturbations_frequency_damping(K, f_i, abs_Omega_K0, k_iMpc):
     if -K * f_i * abs_Omega_K0 >= 1:
         with pytest.raises(Exception):
@@ -103,8 +103,8 @@ def test_perturbations_frequency_damping(K, f_i, abs_Omega_K0, k_iMpc):
         assert np.isfinite(damp_t).all()
         assert np.isfinite(damp_n).all()
 
-        pert_t = solve_oscode(background=bist, k=k, rtol=5e-5)
-        pert_n = solve_oscode(background=bisn, k=k, rtol=5e-5, even_grid=True)
+        pert_t = solve_oscode(background=bist, k=k, rtol=1e-5)
+        pert_n = solve_oscode(background=bisn, k=k, rtol=1e-5, even_grid=True)
         for sol in ['one', 'two']:
             assert np.all(np.isfinite(getattr(getattr(pert_t.scalar, sol), 't')))
             assert np.all(np.isfinite(getattr(getattr(pert_n.scalar, sol), 'N')))

--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -31,7 +31,7 @@ def test_inflationary_potentials(Pot, pot_kwargs, Lambda, phi):
     pot.d2V(phi=phi)
     pot.d3V(phi=phi)
     assert pot.inv_V(V=Lambda**4/2) > 0
-    if type(pot) == pp.DoubleWellPotential:
+    if type(pot) is pp.DoubleWellPotential:
         with pytest.raises(NotImplementedError):
             pot.sr_As2Lambda(A_s=2e-9, phi_star=None, N_star=60, **pot_kwargs)
     else:


### PR DESCRIPTION
Introduce `idx_beg` (analogous to `idx_end`) to be able to start integration of perturbations from fraction of the horizon size to speed up computation, especially for slow-roll initial conditions which otherwise might end up very slow.


# Checklist:

- [x] I have performed a self-review of my own code.
- [x] My code is PEP8 compliant (`flake8 --max-line-length 99 primpy tests`).
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `anesthetic/__version__.py`.
