### PR TITLE
Use `logw=True` for oscode!

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -6,29 +6,18 @@ name: primpy CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
-  version-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-      - name: pip setup
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade packaging
-      - name: Check version number
-        run: python ./.github/workflows/check_version.py
-
   lint:
-    # Test for pep-compliance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - name: Upgrade pip and install linters
         run: |
           python -m pip install --upgrade pip
@@ -48,28 +37,28 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --upgrade setuptools
+        python -m pip install --upgrade setuptools
         pip install -r requirements.txt
+
     - name: Install testing packages
       run: |
-        pip install pytest
-        pip install pytest-cov pytest-xdist codecov  
-    
-    # Run tests
+        python -m pip install pytest
+        python -m pip install pytest-cov pytest-xdist codecov  
+
     - name: Test with pytest
-      run: |
-        python -m pytest --cov=primpy --cov-report=xml
-    
-    # Check code coverage
-    - name: Upload coverage reports to Codecov with GitHub Action
-      uses: codecov/codecov-action@v3
+      run: python -m pytest --cov=primpy --cov-report=xml
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/check_version.py
+++ b/.github/workflows/check_version.py
@@ -5,7 +5,8 @@ from packaging import version
 
 
 def run(*args):
-    return subprocess.run(args,
+    """Run a bash command and return the output in Python."""
+    return subprocess.run(args, 
                           text=True,
                           stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE).stdout
@@ -38,19 +39,19 @@ def unit_incremented(a, b):
 
 
 README = "README.rst"
-versionfile = "primpy/__version__.py"
-current_version = run("cat", versionfile)
+vfile = "primpy/__version__.py"
+current_version = run("cat", vfile)
 current_version = current_version.split("=")[-1].strip().strip("'")
 
 run("git", "fetch", "origin", "master")
-previous_version = run("git", "show", "remotes/origin/master:" + versionfile)
+previous_version = run("git", "show", "remotes/origin/master:" + vfile)
 previous_version = previous_version.split("=")[-1].strip().strip("'")
 
 readme_version = run("grep", ":Version:", README)
 readme_version = readme_version.split(":")[-1].strip()
 
 if version.parse(current_version) != version.parse(readme_version):
-    sys.stderr.write("Version mismatch: {} != {}".format(versionfile, README))
+    sys.stderr.write("Version mismatch: {} != {}".format(vfile, README))
     sys.exit(1)
 elif not unit_incremented(current_version, previous_version):
     sys.stderr.write(("Version must be incremented by one:\n"

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -1,0 +1,18 @@
+name: PR checks
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - name: Upgrade pip and install linters
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade packaging
+      - name: Check version number
+        run: python ./.github/workflows/check_version.py

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.7.0
+:Version: 2.7.1
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/bin/bump_version.py
+++ b/bin/bump_version.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+from utils import run
+from packaging import version
+import sys
+
+vfile = "primpy/__version__.py"
+README = "README.rst"
+
+current_version = run("cat", vfile)
+current_version = current_version.split("=")[-1].strip().strip("'")
+escaped_version = current_version.replace(".", "\.")
+current_version = version.parse(current_version)
+
+if len(sys.argv) > 1:
+    update_type = sys.argv[1]
+else:
+    update_type = "micro"
+
+major = current_version.major
+minor = current_version.minor
+micro = current_version.micro
+
+if update_type == "micro":
+    micro += 1
+elif update_type == "minor":
+    minor += 1
+    micro = 0
+elif update_type == "major":
+    major += 1
+    minor = 0
+    micro = 0
+
+new_version = version.parse(f"{major}.{minor}.{micro}")
+
+for f in [vfile, README]:
+    if sys.platform == "darwin":  # macOS sed requires empty string for backup
+        run("sed", "-i", "", f"s/{escaped_version}/{new_version}/g", f)
+    else:
+        run("sed", "-i", f"s/{escaped_version}/{new_version}/g", f)
+
+#run("git", "add", vfile, README)
+#run("git", "commit", "-m", f"bump version to {new_version}")

--- a/bin/bump_version.py
+++ b/bin/bump_version.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python
-from utils import run
-from packaging import version
 import sys
+import subprocess
+from packaging import version
 
 vfile = "primpy/__version__.py"
 README = "README.rst"
+
+
+def run(*args):
+    """Run a bash command and return the output in Python."""
+    return subprocess.run(args, text=True,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE).stdout
+
 
 current_version = run("cat", vfile)
 current_version = current_version.split("=")[-1].strip().strip("'")

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -1,0 +1,35 @@
+from packaging import version
+import subprocess
+
+
+def run(*args):
+    """Run a bash command and return the output in Python."""
+    return subprocess.run(args, text=True,
+                          stdout=subprocess.PIPE,
+                          stderr=subprocess.PIPE).stdout
+
+
+def unit_incremented(a, b):
+    """Check if a is one version larger than b."""
+    a = version.parse(a)
+    b = version.parse(b)
+    if a.pre is not None and b.pre is not None:
+        if a.pre[0] == b.pre[0]:
+            return a.pre[1] == b.pre[1]+1 and a.base_version == b.base_version
+        else:
+            return (a.pre[1] == 0 and a.pre[0] > b.pre[0]
+                    and a.base_version == b.base_version)
+    elif a.pre is not None:
+        return a.base_version > b.base_version and a.pre[1] == 0
+    elif b.pre is not None:
+        return a.base_version == b.base_version
+    else:
+        return (a.micro == b.micro+1 and
+                a.minor == b.minor and
+                a.major == b.major or
+                a.micro == 0 and
+                a.minor == b.minor+1 and
+                a.major == b.major or
+                a.micro == 0 and
+                a.minor == 0 and
+                a.major == b.major+1)

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 """:mod:`primpy.__version__`: version file for primpy."""
 
-__version__ = '2.7.0'
+__version__ = '2.7.1'

--- a/primpy/oscode_solver.py
+++ b/primpy/oscode_solver.py
@@ -104,7 +104,7 @@ def solve_oscode(background, k, **kwargs):
             for num in range(2):
                 oscode_sol.append(pyoscode.solve(ts=b.x[idx_beg:idx_end+1],
                                                  ti=b.x[idx_beg], tf=b.x[idx_end],
-                                                 ws=mode.ms_frequency, logw=False,
+                                                 ws=np.log(mode.ms_frequency), logw=True,
                                                  gs=mode.ms_damping, logg=False,
                                                  x0=y0[2*num]*ki,
                                                  dx0=y0[2*num+1]*ki**2,

--- a/tests/test_perturbations.py
+++ b/tests/test_perturbations.py
@@ -60,8 +60,8 @@ def test_perturbations_SR():
     ks_iMpc = np.logspace(np.log10(5e-4), np.log10(5e0), 4 * 10 + 1)
     logk_iMpc = np.log(ks_iMpc)
     ks_cont = ks_iMpc * bsrt.a0_Mpc
-    pps_t = solve_oscode(background=bsrt, k=ks_cont, fac_beg=100, rtol=1e-5)
-    pps_n = solve_oscode(background=bsrn, k=ks_cont, fac_beg=100, rtol=1e-5, even_grid=True)
+    pps_t = solve_oscode(background=bsrt, k=ks_cont, fac_beg=100, rtol=5e-5)
+    pps_n = solve_oscode(background=bsrn, k=ks_cont, fac_beg=100, rtol=5e-5, even_grid=True)
     assert np.isfinite(pps_t.P_s_RST).all()
     assert np.isfinite(pps_t.P_t_RST).all()
     assert np.isfinite(pps_n.P_s_RST).all()
@@ -93,7 +93,7 @@ def set_background_IS(K, f_i, abs_Omega_K0):
 
     eq_t = InflationEquationsT(K=K, potential=pot)
     eq_n = InflationEquationsN(K=K, potential=pot)
-    t_eval = np.logspace(np.log10(5e4), np.log10(4e6), int(1e5))
+    t_eval = np.logspace(np.log10(5e4), np.log10(4e6), int(5e4))
     ic_t = InflationStartIC(eq_t, phi_i=phi_i, Omega_Ki=Omega_Ki, t_i=t_eval[0])
     ic_n = InflationStartIC(eq_n, phi_i=phi_i, Omega_Ki=Omega_Ki, t_i=None)
     N_eval = np.linspace(ic_n.N_i, 70, int(1e5))
@@ -172,8 +172,8 @@ def test_perturbations_frequency_damping(K, f_i, abs_Omega_K0, k_iMpc):
         assert np.isfinite(damp_t).all()
         assert np.isfinite(damp_n).all()
 
-        pert_t = solve_oscode(background=bist, k=k, rtol=1e-5)
-        pert_n = solve_oscode(background=bisn, k=k, rtol=1e-5, even_grid=True)
+        pert_t = solve_oscode(background=bist, k=k, rtol=5e-5)
+        pert_n = solve_oscode(background=bisn, k=k, rtol=5e-5, even_grid=True)
         for sol in ['one', 'two']:
             assert np.all(np.isfinite(getattr(getattr(pert_t.scalar, sol), 't')))
             assert np.all(np.isfinite(getattr(getattr(pert_n.scalar, sol), 'N')))
@@ -193,8 +193,8 @@ def test_perturbations_discrete_time_efolds(K, f_i, abs_Omega_K0):
     else:
         bist, bisn = set_background_IS(K=K, f_i=f_i, abs_Omega_K0=abs_Omega_K0)
         ks_disc = np.arange(1, 100, 1)
-        pps_t = solve_oscode(background=bist, k=ks_disc, rtol=1e-5)
-        pps_n = solve_oscode(background=bisn, k=ks_disc, rtol=1e-5, even_grid=True)
+        pps_t = solve_oscode(background=bist, k=ks_disc, rtol=5e-5)
+        pps_n = solve_oscode(background=bisn, k=ks_disc, rtol=5e-5, even_grid=True)
         assert np.isfinite(pps_t.P_s_RST).all()
         assert np.isfinite(pps_t.P_t_RST).all()
         assert np.isfinite(pps_n.P_s_RST).all()


### PR DESCRIPTION
It actually makes a huge difference in oscode whether `logw` is set to true or to false for computing the mode evolution. Setting it to true runs much faster and gives much more accurate results. Oscode struggles visibly less as can be seen by the much larger steps.

# Checklist:

- [x] I have performed a self-review of my own code.
- [ ] My code is PEP8 compliant (`flake8 --max-line-length 99 primpy tests`).
- [ ] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
- [ ] New and existing unit tests pass locally with my changes (`python -m pytest`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `anesthetic/__version__.py`.
