### PR TITLE
Fix automatic pypi upload 4

### DIFF
--- a/.github/workflows/tag-release-publish.yaml
+++ b/.github/workflows/tag-release-publish.yaml
@@ -60,4 +60,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-          repository-url: https://pypi.org/p/primpy/
+          repository-url: https://upload.pypi.org/legacy/

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.7.7
+:Version: 2.7.8
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 """:mod:`primpy.__version__`: version file for primpy."""
 
-__version__ = '2.7.7'
+__version__ = '2.7.8'


### PR DESCRIPTION
Apparently I need to use a different repository-url: https://test.pypi.org/legacy/

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] My code is PEP8 compliant (`flake8 --max-line-length 99 primpy tests`).
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `anesthetic/__version__.py`.
