### PR TITLE
Fix readme badges 2

### DIFF
--- a/.github/workflows/tag-release-publish.yaml
+++ b/.github/workflows/tag-release-publish.yaml
@@ -61,3 +61,10 @@ jobs:
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           repository-url: https://upload.pypi.org/legacy/
+
+  purge-image-cache:
+    name: Purge image cache from badges in README
+    needs: build-n-publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kevincobain2000/action-camo-purge@v1

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.9.4
+:Version: 2.9.5
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,3 +1,3 @@
 """Version file for primpy."""
 
-__version__ = '2.9.4'
+__version__ = '2.9.5'


### PR DESCRIPTION
Readme badges are still not updating correctly. Attempting to make things work by purging the image cache after PR merging with [this workflow action](https://github.com/kevincobain2000/action-camo-purge).