### PR TITLE
Update metadata

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -10,7 +10,7 @@ on:
   pull_request:
     branches: [master]
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 5 * * 1"
 
 jobs:
   lint:

--- a/README.rst
+++ b/README.rst
@@ -16,9 +16,9 @@ primpy: calculations for the primordial Universe
 .. image:: https://readthedocs.org/projects/primpy/badge/?version=latest
     :target: https://primpy.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
-.. image:: https://badge.fury.io/py/primpy.svg?
-    :target: https://badge.fury.io/py/primpy
-    :alt: PyPi version
+.. image:: https://img.shields.io/pypi/v/primpy?cacheSeconds=86400
+    :alt: PyPI - Version
+
 
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.9.5
+:Version: 2.9.6
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,3 +1,3 @@
 """Version file for primpy."""
 
-__version__ = '2.9.5'
+__version__ = '2.9.6'

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     long_description=open('README.rst').read(),
     keywords="PPS, cosmic inflation, initial conditions for inflation, kinetic dominance",
     author="Lukas Hergt",
-    author_email="lh561@mrao.cam.ac.uk",
+    author_email="lukas.hergt@ijclab.in2p3.fr",
     packages=find_packages(),
     install_requires=[
         'numpy',
@@ -26,14 +26,15 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Science/Research",
-        "Natural Language :: English",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.7",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Scientific/Engineering :: Physics",
         "Topic :: Scientific/Engineering :: Astronomy",
-        "Operating System :: OS Independent",
     ],
 )


### PR DESCRIPTION
Metadata was showing outdated python version support, which is updated now.
Python 3.7 dropped, python 3.11 and 3.12 added. 

Also reducing the cron schedule frequency to once per week.