### PR TITLE
Fix pypi target

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,10 @@ primpy: calculations for the primordial Universe
     :target: https://codecov.io/gh/lukashergt/primpy
     :alt: Test Coverage
 .. image:: https://readthedocs.org/projects/primpy/badge/?version=latest
-    :target: https://primpy.readthedocs.io/en/latest/?badge=latest
+    :target: https://primpy.readthedocs.io/en/latest
     :alt: Documentation Status
 .. image:: https://img.shields.io/pypi/v/primpy?cacheSeconds=86400
+    :target: https://img.shields.io/pypi/v/primpy
     :alt: PyPI - Version
 
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.9.6
+:Version: 2.9.7
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ primpy: calculations for the primordial Universe
     :target: https://primpy.readthedocs.io/en/latest
     :alt: Documentation Status
 .. image:: https://img.shields.io/pypi/v/primpy?cacheSeconds=86400
-    :target: https://img.shields.io/pypi/v/primpy
+    :target: https://pypi.org/project/primpy
     :alt: PyPI - Version
 
 

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,3 +1,3 @@
 """Version file for primpy."""
 
-__version__ = '2.9.6'
+__version__ = '2.9.7'


### PR DESCRIPTION
I didn't specify a link target for the PyPI badge, directing it directly to the PyPI page now.