### PR TITLE
Hamiltonian dioganalisation vacuum initial conditions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.9.7
+:Version: 2.10.0
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/bin/bump_version.py
+++ b/bin/bump_version.py
@@ -16,7 +16,7 @@ def run(*args):
 
 current_version = run("cat", vfile)
 current_version = current_version.split("=")[-1].strip().strip("'")
-escaped_version = current_version.replace(".", "\.")
+escaped_version = current_version.replace(".", r"\.")
 current_version = version.parse(current_version)
 
 if len(sys.argv) > 1:

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,3 +1,3 @@
 """Version file for primpy."""
 
-__version__ = '2.9.7'
+__version__ = '2.10.0'

--- a/primpy/efolds/inflation.py
+++ b/primpy/efolds/inflation.py
@@ -71,7 +71,7 @@ class InflationEquationsN(InflationEquations):
     @staticmethod
     def get_d3H(N, H, dH, d2H, dphi, d2phi, d3phi, K):
         # here: d3H/dN3
-        d3H = (-d3phi*dphi*H - d2phi**2*H - dphi**2*d2H/2 - 2*d2phi*dphi*dH 
+        d3H = (-d3phi*dphi*H - d2phi**2*H - dphi**2*d2H/2 - 2*d2phi*dphi*dH
                + K*np.exp(-2*N) * (4*H-d2H+4*dH+2*dH**2/H) / H**2)
         return d3H
 
@@ -87,9 +87,9 @@ class InflationEquationsN(InflationEquations):
 
     @staticmethod
     def get_d4phi(H, dH, d2H, d3H, dphi, d2phi, d3phi, dV, d2V, d3V):
-        return ((-3 - dH/H)*d3phi 
-                + (-2*d2H/H - d2V/H**2 + 2*dH**2/H**2)*d2phi 
-                + (-d3H/H - d3V*dphi/H**2 + 3*d2H*dH/H**2 + 4*d2V*dH/H**3 - 2*dH**3/H**3)*dphi 
+        return ((-3 - dH/H)*d3phi
+                + (-2*d2H/H - d2V/H**2 + 2*dH**2/H**2)*d2phi
+                + (-d3H/H - d3V*dphi/H**2 + 3*d2H*dH/H**2 + 4*d2V*dH/H**3 - 2*dH**3/H**3)*dphi
                 + 2*(d2H/H - 3*dH**2/H**2)*dV/H**2)
 
     def H2(self, x, y):

--- a/primpy/efolds/inflation.py
+++ b/primpy/efolds/inflation.py
@@ -71,9 +71,8 @@ class InflationEquationsN(InflationEquations):
     @staticmethod
     def get_d3H(N, H, dH, d2H, dphi, d2phi, d3phi, K):  # noqa: D102
         # here: d3H/dN3
-        d3H = (-d3phi*dphi*H - d2phi**2*H - dphi**2*d2H/2 - 2*d2phi*dphi*dH
-               + K*np.exp(-2*N) * (4*H-d2H+4*dH+2*dH**2/H) / H**2)
-        return d3H
+        return (-d3phi*dphi*H - d2phi**2*H - dphi**2*d2H/2 - 2*d2phi*dphi*dH
+                + K*np.exp(-2*N) * (4*H-d2H+4*dH+2*dH**2/H) / H**2)
 
     @staticmethod
     def get_d2phi(H2, dH_H, dphi, dV):  # noqa: D102
@@ -93,13 +92,15 @@ class InflationEquationsN(InflationEquations):
                 + 2*(d2H/H - 3*dH**2/H**2)*dV/H**2)
 
     def H2(self, x, y):  # noqa: D102
-        return self.get_H2(N=x, dphi=self.dphidN(x, y), V=self.V(x, y), K=self.K)
+        V = self.V(x, y)
+        dphi = self.dphidN(x, y)
+        return self.get_H2(N=x, dphi=dphi, V=V, K=self.K)
 
     def w(self, x, y):  # noqa: D102
         V = self.V(x, y)
-        dphidt2 = self.H2(x, y) * self.dphidN(x, y)**2
-        p = dphidt2 / 2 - V
-        rho = dphidt2 / 2 + V
+        dphidt_2 = self.H2(x, y) * self.dphidN(x, y)**2
+        p = dphidt_2 / 2 - V
+        rho = dphidt_2 / 2 + V
         return p / rho
 
     def inflating(self, x, y):  # noqa: D102

--- a/primpy/efolds/inflation.py
+++ b/primpy/efolds/inflation.py
@@ -37,20 +37,64 @@ class InflationEquationsN(InflationEquations):
         """System of coupled ODEs for underlying variables."""
         H2 = self.H2(x, y)
         dphidN = self.dphidN(x, y)
-        dH_H = -dphidN**2 / 2 + self.K * np.exp(-2 * x) / H2
+        dH_H = self.get_dH_H(N=x, H2=H2, dphi=dphidN, K=self.K)
+        dVdphi = self.dVdphi(x, y)
 
         dy = np.zeros_like(y)
         dy[self.idx['phi']] = dphidN
-        dy[self.idx['dphidN']] = -(dH_H + 3) * dphidN - self.dVdphi(x, y) / H2
+        dy[self.idx['dphidN']] = self.get_d2phi(H2=H2, dH_H=dH_H, dphi=dphidN, dV=dVdphi)
         if self.track_time:
             dy[self.idx['t']] = 1 / np.sqrt(H2)
         if self.track_eta:
             dy[self.idx['eta']] = np.exp(-x) / np.sqrt(H2)
         return dy
 
+    @staticmethod
+    def get_H2(N, dphi, V, K):
+        return (2 * V - 6 * K * np.exp(-2 * N)) / (6 - dphi**2)
+
+    @staticmethod
+    def get_dH(N, H, dphi, K):
+        # here: dH/dN
+        return -dphi**2 * H / 2 + K * np.exp(-2 * N) / H
+
+    @staticmethod
+    def get_dH_H(N, H2, dphi, K):
+        # here: dH/dN / H
+        return -dphi**2 / 2 + K * np.exp(-2 * N) / H2
+
+    @staticmethod
+    def get_d2H(N, H, dH, dphi, d2phi, K):
+        # here: d2H/dN2
+        return -d2phi * dphi * H - dphi**2 * dH / 2 - K * np.exp(-2 * N) * (2 * H + dH) / H**2
+
+    @staticmethod
+    def get_d3H(N, H, dH, d2H, dphi, d2phi, d3phi, K):
+        # here: d3H/dN3
+        d3H = (-d3phi*dphi*H - d2phi**2*H - dphi**2*d2H/2 - 2*d2phi*dphi*dH 
+               + K*np.exp(-2*N) * (4*H-d2H+4*dH+2*dH**2/H) / H**2)
+        return d3H
+
+    @staticmethod
+    def get_d2phi(H2, dH_H, dphi, dV):
+        # here: d2phi/dN2
+        return -(dH_H + 3) * dphi - dV / H2
+
+    @staticmethod
+    def get_d3phi(H, dH, d2H, dphi, d2phi, dV, d2V):
+        # here: d3phi/dN3
+        return (-3-dH/H)*d2phi + (-d2H/H - d2V/H**2 + dH**2/H**2)*dphi + 2*dV*dH/H**3
+
+    @staticmethod
+    def get_d4phi(H, dH, d2H, d3H, dphi, d2phi, d3phi, dV, d2V, d3V):
+        return ((-3 - dH/H)*d3phi 
+                + (-2*d2H/H - d2V/H**2 + 2*dH**2/H**2)*d2phi 
+                + (-d3H/H - d3V*dphi/H**2 + 3*d2H*dH/H**2 + 4*d2V*dH/H**3 - 2*dH**3/H**3)*dphi 
+                + 2*(d2H/H - 3*dH**2/H**2)*dV/H**2)
+
     def H2(self, x, y):
         """Compute the square of the Hubble parameter using the Friedmann equation."""
-        return (2 * self.V(x, y) - 6 * self.K * np.exp(-2 * x)) / (6 - self.dphidN(x, y)**2)
+        return self.get_H2(N=x, dphi=self.dphidN(x, y), V=self.V(x, y), K=self.K)
 
     def w(self, x, y):
         """Compute the equation of state parameter."""

--- a/primpy/efolds/inflation.py
+++ b/primpy/efolds/inflation.py
@@ -92,9 +92,7 @@ class InflationEquationsN(InflationEquations):
                 + 2*(d2H/H - 3*dH**2/H**2)*dV/H**2)
 
     def H2(self, x, y):  # noqa: D102
-        V = self.V(x, y)
-        dphi = self.dphidN(x, y)
-        return self.get_H2(N=x, dphi=dphi, V=V, K=self.K)
+        return self.get_H2(N=x, dphi=self.dphidN(x, y), V=self.V(x, y), K=self.K)
 
     def w(self, x, y):  # noqa: D102
         V = self.V(x, y)

--- a/primpy/efolds/inflation.py
+++ b/primpy/efolds/inflation.py
@@ -33,7 +33,7 @@ class InflationEquationsN(InflationEquations):
         if track_eta:
             self.add_variable('eta')
 
-    def __call__(self, x, y):
+    def __call__(self, x, y):  # noqa: D102
         """System of coupled ODEs for underlying variables."""
         H2 = self.H2(x, y)
         dphidN = self.dphidN(x, y)
@@ -50,65 +50,61 @@ class InflationEquationsN(InflationEquations):
         return dy
 
     @staticmethod
-    def get_H2(N, dphi, V, K):
+    def get_H2(N, dphi, V, K):  # noqa: D102
         return (2 * V - 6 * K * np.exp(-2 * N)) / (6 - dphi**2)
 
     @staticmethod
-    def get_dH(N, H, dphi, K):
+    def get_dH(N, H, dphi, K):  # noqa: D102
         # here: dH/dN
         return -dphi**2 * H / 2 + K * np.exp(-2 * N) / H
 
     @staticmethod
-    def get_dH_H(N, H2, dphi, K):
+    def get_dH_H(N, H2, dphi, K):  # noqa: D102
         # here: dH/dN / H
         return -dphi**2 / 2 + K * np.exp(-2 * N) / H2
 
     @staticmethod
-    def get_d2H(N, H, dH, dphi, d2phi, K):
+    def get_d2H(N, H, dH, dphi, d2phi, K):  # noqa: D102
         # here: d2H/dN2
         return -d2phi * dphi * H - dphi**2 * dH / 2 - K * np.exp(-2 * N) * (2 * H + dH) / H**2
 
     @staticmethod
-    def get_d3H(N, H, dH, d2H, dphi, d2phi, d3phi, K):
+    def get_d3H(N, H, dH, d2H, dphi, d2phi, d3phi, K):  # noqa: D102
         # here: d3H/dN3
         d3H = (-d3phi*dphi*H - d2phi**2*H - dphi**2*d2H/2 - 2*d2phi*dphi*dH
                + K*np.exp(-2*N) * (4*H-d2H+4*dH+2*dH**2/H) / H**2)
         return d3H
 
     @staticmethod
-    def get_d2phi(H2, dH_H, dphi, dV):
+    def get_d2phi(H2, dH_H, dphi, dV):  # noqa: D102
         # here: d2phi/dN2
         return -(dH_H + 3) * dphi - dV / H2
 
     @staticmethod
-    def get_d3phi(H, dH, d2H, dphi, d2phi, dV, d2V):
+    def get_d3phi(H, dH, d2H, dphi, d2phi, dV, d2V):  # noqa: D102
         # here: d3phi/dN3
         return (-3-dH/H)*d2phi + (-d2H/H - d2V/H**2 + dH**2/H**2)*dphi + 2*dV*dH/H**3
 
     @staticmethod
-    def get_d4phi(H, dH, d2H, d3H, dphi, d2phi, d3phi, dV, d2V, d3V):
+    def get_d4phi(H, dH, d2H, d3H, dphi, d2phi, d3phi, dV, d2V, d3V):  # noqa: D102
         return ((-3 - dH/H)*d3phi
                 + (-2*d2H/H - d2V/H**2 + 2*dH**2/H**2)*d2phi
                 + (-d3H/H - d3V*dphi/H**2 + 3*d2H*dH/H**2 + 4*d2V*dH/H**3 - 2*dH**3/H**3)*dphi
                 + 2*(d2H/H - 3*dH**2/H**2)*dV/H**2)
 
-    def H2(self, x, y):
-        """Compute the square of the Hubble parameter using the Friedmann equation."""
+    def H2(self, x, y):  # noqa: D102
         return self.get_H2(N=x, dphi=self.dphidN(x, y), V=self.V(x, y), K=self.K)
 
-    def w(self, x, y):
-        """Compute the equation of state parameter."""
+    def w(self, x, y):  # noqa: D102
         V = self.V(x, y)
         dphidt2 = self.H2(x, y) * self.dphidN(x, y)**2
         p = dphidt2 / 2 - V
         rho = dphidt2 / 2 + V
         return p / rho
 
-    def inflating(self, x, y):
-        """Inflation diagnostic for event tracking."""
+    def inflating(self, x, y):  # noqa: D102
         return self.V(x, y) - self.H2(x, y) * self.dphidN(x, y)**2
 
-    def sol(self, sol, **kwargs):
-        """Post-processing of :func:`scipy.integrate.solve_ivp` solution."""
+    def sol(self, sol, **kwargs):  # noqa: D102
         sol = super(InflationEquationsN, self).sol(sol, **kwargs)
         return sol

--- a/primpy/efolds/perturbations.py
+++ b/primpy/efolds/perturbations.py
@@ -100,7 +100,7 @@ class ScalarModeN(ScalarMode):
         z_i = a_i * dphi_i
         dz_z_i = d2phi_i / dphi_i + 1
         d2z_z_i = d3phi_i / dphi_i + 2 * d2phi_i / dphi_i + 1
-        
+
         wk_i = a_i * H_i * np.sqrt(self.k**2/(a_i*H_i)**2 - (1+dH_i/H_i) * dz_z_i - d2z_z_i)
 
         Rk_i = 1 / np.sqrt(2 * wk_i) / z_i

--- a/primpy/efolds/perturbations.py
+++ b/primpy/efolds/perturbations.py
@@ -46,9 +46,8 @@ class ScalarModeN(ScalarMode):
         """
         K = self.background.K
         a2 = np.exp(2 * self.background._N[self.idx_beg:self.idx_end+1])
-        H = self.background.H[self.idx_beg:self.idx_end+1]
         dphidN = self.background.dphidN[self.idx_beg:self.idx_end+1]
-        H2 = H**2
+        H = self.background.H[self.idx_beg:self.idx_end+1]
         dV = self.background.potential.dV(self.background.phi[self.idx_beg:self.idx_end+1])
         Omega_K = self.background.Omega_K[self.idx_beg:self.idx_end+1]
 
@@ -56,8 +55,8 @@ class ScalarModeN(ScalarMode):
         epsilon = dphidN**2 / 2
         xi = Omega_K + epsilon - 3
 
-        damping2 = 2 * kappa2 / (kappa2 + K * epsilon) * (xi - dV / (H2 * dphidN)) - xi
-        frequency2 = kappa2 / (a2 * H2) + (damping2 + xi + 1) * Omega_K
+        damping2 = 2 * kappa2 / (kappa2 + K * epsilon) * (xi - dV / (H**2 * dphidN)) - xi
+        frequency2 = kappa2 / (a2 * H**2) + (damping2 + xi + 1) * Omega_K
         if np.all(frequency2 > 0):
             return np.sqrt(frequency2), damping2 / 2
         else:
@@ -110,8 +109,9 @@ class ScalarModeN(ScalarMode):
     def get_vacuum_ic_RST(self):
         """Get initial conditions for scalar modes for RST vacuum w.r.t. e-folds `_N`."""
         a_i = np.exp(self.background._N[self.idx_beg])
+        dphi_i = self.background.dphidN[self.idx_beg]
         H_i = self.background.H[self.idx_beg]
-        z_i = a_i * self.background.dphidN[self.idx_beg]
+        z_i = a_i * dphi_i
         Rk_i = 1 / np.sqrt(2 * self.k) / z_i
         dRk_i = -1j * self.k / (a_i * H_i) * Rk_i
         return Rk_i, dRk_i

--- a/primpy/efolds/perturbations.py
+++ b/primpy/efolds/perturbations.py
@@ -1,5 +1,6 @@
 """Curvature perturbations with respect to e-folds `_N`."""
 import numpy as np
+from primpy.efolds.inflation import InflationEquationsN as Eq
 from primpy.perturbations import Perturbation, ScalarMode, TensorMode
 
 
@@ -62,6 +63,50 @@ class ScalarModeN(ScalarMode):
         else:
             return np.sqrt(frequency2 + 0j), damping2 / 2
 
+    def get_vacuum_ic_k(self):
+        """Get initial conditions for scalar modes for HD approximation w.r.t. e-folds `_N`."""
+        N_i = self.background._N[self.idx_beg]
+        a_i = np.exp(N_i)
+        H_i = self.background.H[self.idx_beg]
+        phi_i = self.background.phi[self.idx_beg]
+        dV_i = self.background.potential.dV(phi_i)
+        dphi_i = self.background.dphidN[self.idx_beg]
+        dH_H_i = Eq.get_dH_H(N=N_i, H2=H_i**2, dphi=dphi_i, K=self.background.K)
+        d2phi_i = Eq.get_d2phi(H2=H_i**2, dH_H=dH_H_i, dphi=dphi_i, dV=dV_i)
+
+        z_i = a_i * dphi_i
+        dz_z_i = d2phi_i / dphi_i + 1
+
+        Rk_i = 1 / np.sqrt(2 * self.k) / z_i
+        dRk_i = (-1j * self.k / (a_i*H_i) - dz_z_i) * Rk_i
+        return Rk_i, dRk_i
+
+    def get_vacuum_ic_HD(self):
+        """Get initial conditions for scalar modes for HD vacuum w.r.t. e-folds `_N`."""
+        N_i = self.background._N[self.idx_beg]
+        a_i = np.exp(N_i)
+        H_i = self.background.H[self.idx_beg]
+        phi_i = self.background.phi[self.idx_beg]
+        dV_i = self.background.potential.dV(phi_i)
+        d2V_i = self.background.potential.d2V(phi_i)
+        dphi_i = self.background.dphidN[self.idx_beg]
+        dH_i = Eq.get_dH(N=N_i, H=H_i, dphi=dphi_i, K=self.background.K)
+        dH_H_i = Eq.get_dH_H(N=N_i, H2=H_i**2, dphi=dphi_i, K=self.background.K)
+        d2phi_i = Eq.get_d2phi(H2=H_i**2, dH_H=dH_H_i, dphi=dphi_i, dV=dV_i)
+        d2H_i = Eq.get_d2H(N=N_i, H=H_i, dH=dH_i, dphi=dphi_i, d2phi=d2phi_i, K=self.background.K)
+        d3phi_i = Eq.get_d3phi(H=H_i, dH=dH_i, d2H=d2H_i, dphi=dphi_i, d2phi=d2phi_i,
+                               dV=dV_i, d2V=d2V_i)
+
+        z_i = a_i * dphi_i
+        dz_z_i = d2phi_i / dphi_i + 1
+        d2z_z_i = d3phi_i / dphi_i + 2 * d2phi_i / dphi_i + 1
+        
+        wk_i = a_i * H_i * np.sqrt(self.k**2/(a_i*H_i)**2 - (1+dH_i/H_i) * dz_z_i - d2z_z_i)
+
+        Rk_i = 1 / np.sqrt(2 * wk_i) / z_i
+        dRk_i = (-1j * wk_i / (a_i*H_i) - dz_z_i) * Rk_i
+        return Rk_i, dRk_i
+
     def get_vacuum_ic_RST(self):
         """Get initial conditions for scalar modes for RST vacuum w.r.t. e-folds `_N`."""
         a_i = np.exp(self.background._N[self.idx_beg])
@@ -101,6 +146,26 @@ class TensorModeN(TensorMode):
             return np.sqrt(frequency2), damping2 / 2
         else:
             return np.sqrt(frequency2 + 0j), damping2 / 2
+
+    def get_vacuum_ic_k(self):
+        """Get initial conditions for tensor modes for HD approximation w.r.t. e-folds `_N`."""
+        a_i = np.exp(self.background._N[self.idx_beg])
+        H_i = self.background.H[self.idx_beg]
+        hk_i = 2 / np.sqrt(2 * self.k) / a_i
+        dhk_i = (-1j * self.k / (a_i*H_i) - 1) * hk_i
+        return hk_i, dhk_i
+
+    def get_vacuum_ic_HD(self):
+        """Get initial conditions for tensor modes for HD vacuum w.r.t. e-folds `_N`."""
+        N_i = self.background._N[self.idx_beg]
+        a_i = np.exp(N_i)
+        H_i = self.background.H[self.idx_beg]
+        dphi_i = self.background.dphidN[self.idx_beg]
+        dH_i = Eq.get_dH(N=N_i, H=H_i, dphi=dphi_i, K=self.background.K)
+        wk_i = a_i * H_i * np.sqrt(self.k**2/(a_i*H_i)**2 - 2 - dH_i/H_i)
+        hk_i = 2 / np.sqrt(2 * wk_i) / a_i
+        dhk_i = (-1j * wk_i / (a_i*H_i) - 1) * hk_i
+        return hk_i, dhk_i
 
     def get_vacuum_ic_RST(self):
         """Get initial conditions for tensor modes for RST vacuum w.r.t. e-folds `_N`."""

--- a/primpy/inflation.py
+++ b/primpy/inflation.py
@@ -19,6 +19,69 @@ class InflationEquations(Equations, ABC):
         self.K = K
         self.potential = potential
 
+    @staticmethod
+    def get_H2(N, dphi, V, K):
+        """Get the Hubble parameter squared from the background equations.
+
+        Returns
+        -------
+        H2 : float or array_like
+        """
+
+    @staticmethod
+    def get_dH(N, H, dphi, K):
+        """Get the 1st time derivative of the Hubble parameter from the background equations.
+
+        Returns
+        -------
+        dH : float or array_like
+        """
+
+    @staticmethod
+    def get_d2H(N, H, dH, dphi, d2phi, K):
+        """Get the 2nd time derivative of the Hubble parameter from the background equations.
+
+        Returns
+        -------
+        d2H : float or array_like
+        """
+
+    @staticmethod
+    def get_d3H(N, H, dH, d2H, dphi, d2phi, d3phi, K):
+        """Get the 3rd time derivative of the Hubble parameter from the background equations.
+
+        Returns
+        -------
+        d3H : float or array_like
+        """
+
+    @staticmethod
+    def get_d2phi(H2, dH_H, dphi, dV):
+        """Get the 2nd time derivative of the inflaton field from the background equations.
+
+        Returns
+        -------
+        d2phi : float or array_like
+        """
+
+    @staticmethod
+    def get_d3phi(H, dH, d2H, dphi, d2phi, dV, d2V):
+        """Get the 3rd time derivative of the inflaton field from the background equations.
+
+        Returns
+        -------
+        d3phi : float or array_like
+        """
+
+    @staticmethod
+    def get_d4phi(H, dH, d2H, d3H, dphi, d2phi, d3phi, dV, d2V, d3V):
+        """Get the 4th time derivative of the inflaton field from the background equations.
+
+        Returns
+        -------
+        d4phi : float or array_like
+        """
+
     def H(self, x, y):
         """Hubble parameter."""
         return np.sqrt(self.H2(x, y))

--- a/primpy/oscode_solver.py
+++ b/primpy/oscode_solver.py
@@ -106,8 +106,8 @@ def solve_oscode(background, k, **kwargs):
                                                  ti=b.x[idx_beg], tf=b.x[idx_end],
                                                  ws=np.log(mode.ms_frequency), logw=True,
                                                  gs=mode.ms_damping, logg=False,
-                                                 x0=y0[2*num]*ki,
-                                                 dx0=y0[2*num+1]*ki**2,
+                                                 x0=y0[2*num],
+                                                 dx0=y0[2*num+1],
                                                  rtol=rtol, even_grid=even_grid))
         p.oscode_postprocessing(oscode_sol=oscode_sol, **kwargs)
         if ki < 1 and b.K == +1 and drop_closed_large_scales:

--- a/primpy/oscode_solver.py
+++ b/primpy/oscode_solver.py
@@ -73,7 +73,7 @@ def solve_oscode(background, k, **kwargs):
     fac_beg = kwargs.pop('fac_beg', 0)
     fac_end = kwargs.pop('fac_end', 100)
     even_grid = kwargs.pop('even_grid', False)
-    vacuum = kwargs.get('vacuum', ('RST',))
+    vacuum = kwargs.get('vacuum', ('k', 'RST'))
     drop_closed_large_scales = kwargs.pop('drop_closed_large_scales', True)
     b = background
     if isinstance(k, int) or isinstance(k, float):

--- a/primpy/oscode_solver.py
+++ b/primpy/oscode_solver.py
@@ -109,7 +109,7 @@ def solve_oscode(background, k, **kwargs):
                                                  x0=y0[2*num]*ki,
                                                  dx0=y0[2*num+1]*ki**2,
                                                  rtol=rtol, even_grid=even_grid))
-        p.oscode_postprocessing(oscode_sol=oscode_sol)
+        p.oscode_postprocessing(oscode_sol=oscode_sol, **kwargs)
         if ki < 1 and b.K == +1 and drop_closed_large_scales:
             p.scalar.P_s_RST = 1e-30
         for vac in vacuum:

--- a/primpy/perturbations.py
+++ b/primpy/perturbations.py
@@ -14,7 +14,7 @@ class PrimordialPowerSpectrum(object):
         self.background = background
         self.k = k
         self.k_iMpc = k * K_STAR / np.exp(background._logaH_star)
-        vacuum = kwargs.pop('vacuum', ('RST',))
+        vacuum = kwargs.pop('vacuum', ('k', 'RST'))
         for vac in vacuum:
             setattr(self, 'P_s_%s' % vac, np.full_like(k, np.nan, dtype=float))
             setattr(self, 'P_t_%s' % vac, np.full_like(k, np.nan, dtype=float))
@@ -53,7 +53,7 @@ class Perturbation(ABC):
         self._combine_solutions(**kwargs)
 
     def _combine_solutions(self, **kwargs):
-        vacuum = kwargs.pop('vacuum', ['RST'])
+        vacuum = kwargs.pop('vacuum', ('k', 'RST'))
         for mode in [self.scalar, self.tensor]:
             y1 = getattr(mode.one, '%s' % mode.var)
             y2 = getattr(mode.two, '%s' % mode.var)
@@ -108,7 +108,7 @@ class ScalarMode(Mode, ABC):
         self.tag = 's'
         self.pps_norm = self.k**3 / (2 * pi**2)
         self.add_variable('Rk', 'dRk')
-        vacuum = kwargs.pop('vacuum', ('RST',))
+        vacuum = kwargs.pop('vacuum', ('k', 'RST'))
         for vac in vacuum:
             setattr(self, 'P_s_%s' % vac, np.nan)
 
@@ -122,6 +122,6 @@ class TensorMode(Mode, ABC):
         self.tag = 't'
         self.pps_norm = self.k**3 / (2 * pi**2) * 2
         self.add_variable('hk', 'dhk')
-        vacuum = kwargs.pop('vacuum', ('RST',))
+        vacuum = kwargs.pop('vacuum', ('k', 'RST'))
         for vac in vacuum:
             setattr(self, 'P_t_%s' % vac, np.nan)

--- a/primpy/potentials.py
+++ b/primpy/potentials.py
@@ -151,7 +151,7 @@ class MonomialPotential(InflationaryPotential):
     tag = 'mnp'
     name = 'MonomialPotential'
     tex = r'$\phi^p$'
-    perturbation_ic = (1e-1, 0, 0, 1e-6)
+    perturbation_ic = (1, 0, 0, 1)
 
     def __init__(self, **pot_kwargs):
         self.p = pot_kwargs.pop('p')
@@ -307,7 +307,7 @@ class QuadraticPotential(MonomialPotential):
     tag = 'mn2'
     name = 'QuadraticPotential'
     tex = r'$\phi^2$'
-    perturbation_ic = (1e-1, 0, 0, 1e-5)
+    perturbation_ic = (1, 0, 0, 1)
 
     def __init__(self, **pot_kwargs):
         if 'mass' in pot_kwargs:
@@ -515,7 +515,7 @@ class StarobinskyPotential(InflationaryPotential):
     name = 'StarobinskyPotential'
     tex = r'Starobinsky'
     gamma = np.sqrt(2 / 3)
-    perturbation_ic = (1-2, 0, 0, 1e-8)
+    perturbation_ic = (1, 0, 0, 1)
 
     def __init__(self, **pot_kwargs):
         super().__init__(**pot_kwargs)
@@ -650,7 +650,7 @@ class NaturalPotential(InflationaryPotential):
     tag = 'nat'
     name = 'NaturalPotential'
     tex = r'Natural'
-    perturbation_ic = (1e-1, 0, 0, 1e-5)
+    perturbation_ic = (1, 0, 0, 1)
 
     def __init__(self, **pot_kwargs):
         self.phi0 = pot_kwargs.pop('phi0')
@@ -788,7 +788,7 @@ class DoubleWellPotential(InflationaryPotential):
     tag = 'dwp'
     name = 'DoubleWellPotential'
     tex = r'Double-Well (p)'
-    perturbation_ic = (1e-1, 0, 0, 1e-5)
+    perturbation_ic = (1, 0, 0, 1)
 
     def __init__(self, **pot_kwargs):
         self.phi0 = pot_kwargs.pop('phi0')
@@ -855,7 +855,7 @@ class DoubleWell2Potential(DoubleWellPotential):
     tag = 'dw2'
     name = 'DoubleWell2Potential'
     tex = r'Double-Well (quadratic)'
-    perturbation_ic = (1e-1, 0, 0, 1e-5)
+    perturbation_ic = (1, 0, 0, 1)
 
     def __init__(self, **pot_kwargs):
         super().__init__(p=2, **pot_kwargs)
@@ -946,7 +946,7 @@ class DoubleWell4Potential(DoubleWellPotential):
     tag = 'dw4'
     name = 'DoubleWell4Potential'
     tex = r'Double-Well (quartic)'
-    perturbation_ic = (1e-1, 0, 0, 1e-5)
+    perturbation_ic = (1, 0, 0, 1)
 
     def __init__(self, **pot_kwargs):
         super().__init__(p=4, **pot_kwargs)

--- a/primpy/time/inflation.py
+++ b/primpy/time/inflation.py
@@ -16,6 +16,7 @@ class InflationEquationsT(InflationEquations):
         * ``_N``: number of e-folds
         * ``phi``: inflaton field
         * ``dphidt``: `d(phi)/dt`
+        * ``eta``: conformal time (optional)
 
     """
 

--- a/primpy/time/inflation.py
+++ b/primpy/time/inflation.py
@@ -86,14 +86,14 @@ class InflationEquationsT(InflationEquations):
     def H2(self, x, y):  # noqa: D102
         _N = self._N(x, y)
         V = self.V(x, y)
-        dphidt = self.dphidt(x, y)
-        return self.get_H2(N=_N, dphi=dphidt, V=V, K=self.K)
+        dphi = self.dphidt(x, y)
+        return self.get_H2(N=_N, dphi=dphi, V=V, K=self.K)
 
     def w(self, x, y):  # noqa: D102
         V = self.V(x, y)
-        dphidt = self.dphidt(x, y)
-        p = dphidt**2 / 2 - V
-        rho = dphidt**2 / 2 + V
+        dphidt_2 = self.dphidt(x, y)**2
+        p = dphidt_2 / 2 - V
+        rho = dphidt_2 / 2 + V
         return p / rho
 
     def inflating(self, x, y):  # noqa: D102

--- a/primpy/time/inflation.py
+++ b/primpy/time/inflation.py
@@ -45,64 +45,60 @@ class InflationEquationsT(InflationEquations):
         return dy
 
     @staticmethod
-    def get_H2(N, dphi, V, K):
+    def get_H2(N, dphi, V, K):  # noqa: D102
         return (dphi**2 / 2 + V) / 3 - K * np.exp(-2 * N)
 
     @staticmethod
-    def get_dH(N, H, dphi, K):
+    def get_dH(N, H, dphi, K):  # noqa: D102
         # here: dH/dt
         return -dphi**2 / 2 + K * np.exp(-2 * N)
 
     @staticmethod
-    def get_dH_H(N, H2, dphi, K):
+    def get_dH_H(N, H2, dphi, K):  # noqa: D102
         # here: dH/dt
         H = np.sqrt(H2)
         return -dphi**2 / (2 * H) + K * np.exp(-2 * N) / H
 
     @staticmethod
-    def get_d2H(N, H, dH, dphi, d2phi, K):
+    def get_d2H(N, H, dH, dphi, d2phi, K):  # noqa: D102
         # here: d2H/dt2
         return -d2phi * dphi - 2 * K * H * np.exp(-2 * N)
 
     @staticmethod
-    def get_d3H(N, H, dH, d2H, dphi, d2phi, d3phi, K):
+    def get_d3H(N, H, dH, d2H, dphi, d2phi, d3phi, K):  # noqa: D102
         # here: d3H/dt3
         return - d3phi * dphi - d2phi**2 + 2 * K * (2 * H**2 - dH) * np.exp(-2 * N)
 
     @staticmethod
-    def get_d2phi(H2, dH_H, dphi, dV):
+    def get_d2phi(H2, dH_H, dphi, dV):  # noqa: D102
         # here: d2phi/dt2
         H = np.sqrt(H2)
         return -3 * H * dphi - dV
 
     @staticmethod
-    def get_d3phi(H, dH, d2H, dphi, d2phi, dV, d2V):
+    def get_d3phi(H, dH, d2H, dphi, d2phi, dV, d2V):  # noqa: D102
         return -3 * H * d2phi - d2V * dphi + 3 * dphi**3 / 2
 
     @staticmethod
-    def get_d4phi(H, dH, d2H, d3H, dphi, d2phi, d3phi, dV, d2V, d3V):
+    def get_d4phi(H, dH, d2H, d3H, dphi, d2phi, d3phi, dV, d2V, d3V):  # noqa: D102
         return -3 * H * d3phi - d2V * d2phi - d3V * dphi**2 - 3 * d2H * dphi - 6 * d2phi * dH
 
-    def H2(self, x, y):
-        """Compute the square of the Hubble parameter using the Friedmann equation."""
+    def H2(self, x, y):  # noqa: D102
         _N = self._N(x, y)
         V = self.V(x, y)
         dphidt = self.dphidt(x, y)
         return self.get_H2(N=_N, dphi=dphidt, V=V, K=self.K)
 
-    def w(self, x, y):
-        """Compute the equation of state parameter."""
+    def w(self, x, y):  # noqa: D102
         V = self.V(x, y)
         dphidt = self.dphidt(x, y)
         p = dphidt**2 / 2 - V
         rho = dphidt**2 / 2 + V
         return p / rho
 
-    def inflating(self, x, y):
-        """Inflation diagnostic for event tracking."""
+    def inflating(self, x, y):  # noqa: D102
         return self.V(x, y) - self.dphidt(x, y)**2
 
-    def sol(self, sol, **kwargs):
-        """Post-processing of :func:`scipy.integrate.solve_ivp` solution."""
+    def sol(self, sol, **kwargs):  # noqa: D102
         sol = super(InflationEquationsT, self).sol(sol, **kwargs)
         return sol

--- a/primpy/time/inflation.py
+++ b/primpy/time/inflation.py
@@ -84,10 +84,7 @@ class InflationEquationsT(InflationEquations):
         return -3 * H * d3phi - d2V * d2phi - d3V * dphi**2 - 3 * d2H * dphi - 6 * d2phi * dH
 
     def H2(self, x, y):  # noqa: D102
-        _N = self._N(x, y)
-        V = self.V(x, y)
-        dphi = self.dphidt(x, y)
-        return self.get_H2(N=_N, dphi=dphi, V=V, K=self.K)
+        return self.get_H2(N=self._N(x, y), dphi=self.dphidt(x, y), V=self.V(x, y), K=self.K)
 
     def w(self, x, y):  # noqa: D102
         V = self.V(x, y)

--- a/primpy/time/perturbations.py
+++ b/primpy/time/perturbations.py
@@ -66,10 +66,10 @@ class ScalarModeT(ScalarMode):
         a_i = np.exp(N_i)
         H_i = self.background.H[self.idx_beg]
         phi_i = self.background.phi[self.idx_beg]
+        dV_i = self.background.potential.dV(phi_i)
         dphi_i = self.background.dphidt[self.idx_beg]
         dH_H_i = Eq.get_dH_H(N=N_i, H2=H_i**2, dphi=dphi_i, K=self.background.K)
-        d2phi_i = Eq.get_d2phi(H2=H_i**2, dH_H=dH_H_i, dphi=dphi_i,
-                               dV=self.background.potential.dV(phi_i))
+        d2phi_i = Eq.get_d2phi(H2=H_i**2, dH_H=dH_H_i, dphi=dphi_i, dV=dV_i)
 
         z_i = a_i * dphi_i / H_i
         dz_z_i = H_i + d2phi_i / dphi_i - dH_H_i
@@ -89,8 +89,7 @@ class ScalarModeT(ScalarMode):
         dphi_i = self.background.dphidt[self.idx_beg]
         dH_i = Eq.get_dH(N=N_i, H=H_i, dphi=dphi_i, K=self.background.K)
         dH_H_i = Eq.get_dH_H(N=N_i, H2=H_i**2, dphi=dphi_i, K=self.background.K)
-        d2phi_i = Eq.get_d2phi(H2=H_i**2, dH_H=dH_H_i, dphi=dphi_i,
-                               dV=self.background.potential.dV(phi_i))
+        d2phi_i = Eq.get_d2phi(H2=H_i**2, dH_H=dH_H_i, dphi=dphi_i, dV=dV_i)
         d2H_i = Eq.get_d2H(N=N_i, H=H_i, dH=dH_i, dphi=dphi_i, d2phi=d2phi_i, K=self.background.K)
         d3phi_i = Eq.get_d3phi(H=H_i, dH=dH_i, d2H=d2H_i, dphi=dphi_i, d2phi=d2phi_i,
                                dV=dV_i, d2V=d2V_i)

--- a/primpy/time/perturbations.py
+++ b/primpy/time/perturbations.py
@@ -1,5 +1,6 @@
 """Curvature perturbations with respect to time `t`."""
 import numpy as np
+from primpy.time.inflation import InflationEquationsT as Eq
 from primpy.perturbations import Perturbation, ScalarMode, TensorMode
 
 
@@ -59,12 +60,57 @@ class ScalarModeT(ScalarMode):
         else:
             return np.sqrt(frequency2 + 0j), damping
 
+    def get_vacuum_ic_k(self):
+        """Get initial conditions for scalar modes for HD approximation w.r.t. cosmic time `t`."""
+        N_i = self.background._N[self.idx_beg]
+        a_i = np.exp(N_i)
+        H_i = self.background.H[self.idx_beg]
+        phi_i = self.background.phi[self.idx_beg]
+        dphi_i = self.background.dphidt[self.idx_beg]
+        dH_H_i = Eq.get_dH_H(N=N_i, H2=H_i**2, dphi=dphi_i, K=self.background.K)
+        d2phi_i = Eq.get_d2phi(H2=H_i**2, dH_H=dH_H_i, dphi=dphi_i,
+                               dV=self.background.potential.dV(phi_i))
+
+        z_i = a_i * dphi_i / H_i
+        dz_z_i = H_i + d2phi_i / dphi_i - dH_H_i
+
+        Rk_i = 1 / np.sqrt(2 * self.k) / z_i
+        dRk_i = (-1j * self.k / a_i - dz_z_i) * Rk_i
+        return Rk_i, dRk_i
+
+    def get_vacuum_ic_HD(self):
+        """Get initial conditions for scalar modes for HD vacuum w.r.t. cosmic time `t`."""
+        N_i = self.background._N[self.idx_beg]
+        a_i = np.exp(N_i)
+        H_i = self.background.H[self.idx_beg]
+        phi_i = self.background.phi[self.idx_beg]
+        dV_i = self.background.potential.dV(phi_i)
+        d2V_i = self.background.potential.d2V(phi_i)
+        dphi_i = self.background.dphidt[self.idx_beg]
+        dH_i = Eq.get_dH(N=N_i, H=H_i, dphi=dphi_i, K=self.background.K)
+        dH_H_i = Eq.get_dH_H(N=N_i, H2=H_i**2, dphi=dphi_i, K=self.background.K)
+        d2phi_i = Eq.get_d2phi(H2=H_i**2, dH_H=dH_H_i, dphi=dphi_i,
+                               dV=self.background.potential.dV(phi_i))
+        d2H_i = Eq.get_d2H(N=N_i, H=H_i, dH=dH_i, dphi=dphi_i, d2phi=d2phi_i, K=self.background.K)
+        d3phi_i = Eq.get_d3phi(H=H_i, dH=dH_i, d2H=d2H_i, dphi=dphi_i, d2phi=d2phi_i,
+                               dV=dV_i, d2V=d2V_i)
+
+        z_i = a_i * dphi_i / H_i
+        dz_z_i = H_i + d2phi_i / dphi_i - dH_H_i
+        d2z_z_i = (H_i**2 + 2 * H_i * d2phi_i / dphi_i + d3phi_i / dphi_i - dH_i
+                   - d2H_i / H_i - 2 * d2phi_i * dH_H_i / dphi_i + 2 * dH_H_i**2)
+        wk_i = a_i * np.sqrt(self.k**2/a_i**2 - H_i * dz_z_i - d2z_z_i)
+
+        Rk_i = 1 / np.sqrt(2 * wk_i) / z_i
+        dRk_i = (-1j * wk_i / a_i - dz_z_i) * Rk_i
+        return Rk_i, dRk_i
+
     def get_vacuum_ic_RST(self):
         """Get initial conditions for scalar modes for RST vacuum w.r.t. cosmic time `t`."""
         a_i = np.exp(self.background._N[self.idx_beg])
-        dphidt_i = self.background.dphidt[self.idx_beg]
+        dphi_i = self.background.dphidt[self.idx_beg]
         H_i = self.background.H[self.idx_beg]
-        z_i = a_i * dphidt_i / H_i
+        z_i = a_i * dphi_i / H_i
         Rk_i = 1 / np.sqrt(2 * self.k) / z_i
         dRk_i = -1j * self.k / a_i * Rk_i
         return Rk_i, dRk_i
@@ -97,6 +143,26 @@ class TensorModeT(TensorMode):
             return np.sqrt(frequency2), damping2 / 2
         else:
             return np.sqrt(frequency2 + 0j), damping2 / 2
+
+    def get_vacuum_ic_k(self):
+        """Get initial conditions for tensor modes for HD approximation w.r.t. cosmic time `t`."""
+        a_i = np.exp(self.background._N[self.idx_beg])
+        H_i = self.background.H[self.idx_beg]
+        hk_i = 2 / np.sqrt(2 * self.k) / a_i
+        dhk_i = (-1j * self.k / a_i - H_i) * hk_i
+        return hk_i, dhk_i
+
+    def get_vacuum_ic_HD(self):
+        """Get initial conditions for tensor modes for HD vacuum w.r.t. cosmic time `t`."""
+        N_i = self.background._N[self.idx_beg]
+        a_i = np.exp(N_i)
+        H_i = self.background.H[self.idx_beg]
+        dphi_i = self.background.dphidt[self.idx_beg]
+        dH_i = Eq.get_dH(N=N_i, H=H_i, dphi=dphi_i, K=self.background.K)
+        wk_i = a_i * np.sqrt(self.k**2/a_i**2 - 2 * H_i**2 - dH_i)
+        hk_i = 2 / np.sqrt(2 * wk_i) / a_i
+        dhk_i = (-1j * wk_i / a_i - H_i) * hk_i
+        return hk_i, dhk_i
 
     def get_vacuum_ic_RST(self):
         """Get initial conditions for tensor modes for RST vacuum w.r.t. cosmic time `t`."""

--- a/tests/test_perturbations.py
+++ b/tests/test_perturbations.py
@@ -55,17 +55,34 @@ def test_perturbations_SR():
     bsrt, bsrn = set_background_SR()
     ks_iMpc = np.logspace(np.log10(5e-4), np.log10(5e0), 4 * 10 + 1)
     logk_iMpc = np.log(ks_iMpc)
-    ks_cont = ks_iMpc * bsrt.a0_Mpc
-    pps_t = solve_oscode(background=bsrt, k=ks_cont, fac_beg=100, rtol=5e-5)
-    pps_n = solve_oscode(background=bsrn, k=ks_cont, fac_beg=100, rtol=5e-5, even_grid=True)
+    ks = ks_iMpc * bsrt.a0_Mpc
+    v = ('k', 'HD', 'RST')
+    pps_t = solve_oscode(background=bsrt, k=ks, vacuum=v, fac_beg=100)
+    pps_n = solve_oscode(background=bsrn, k=ks, vacuum=v, fac_beg=100, even_grid=True)
+    assert np.isfinite(pps_t.P_s_k).all()
+    assert np.isfinite(pps_t.P_t_k).all()
+    assert np.isfinite(pps_n.P_s_k).all()
+    assert np.isfinite(pps_n.P_t_k).all()
+    assert np.isfinite(pps_t.P_s_HD).all()
+    assert np.isfinite(pps_t.P_t_HD).all()
+    assert np.isfinite(pps_n.P_s_HD).all()
+    assert np.isfinite(pps_n.P_t_HD).all()
     assert np.isfinite(pps_t.P_s_RST).all()
     assert np.isfinite(pps_t.P_t_RST).all()
     assert np.isfinite(pps_n.P_s_RST).all()
     assert np.isfinite(pps_n.P_t_RST).all()
 
     # time vs efolds
+    assert_allclose(pps_t.P_s_k * 1e9, pps_n.P_s_k * 1e9, rtol=1e-3, atol=1e-6)
+    assert_allclose(pps_t.P_t_k * 1e9, pps_n.P_t_k * 1e9, rtol=1e-3, atol=1e-6)
+    assert_allclose(pps_t.P_s_HD * 1e9, pps_n.P_s_HD * 1e9, rtol=1e-3, atol=1e-6)
+    assert_allclose(pps_t.P_t_HD * 1e9, pps_n.P_t_HD * 1e9, rtol=1e-3, atol=1e-6)
     assert_allclose(pps_t.P_s_RST * 1e9, pps_n.P_s_RST * 1e9, rtol=1e-3, atol=1e-6)
     assert_allclose(pps_t.P_t_RST * 1e9, pps_n.P_t_RST * 1e9, rtol=1e-3, atol=1e-6)
+
+    # k vs HD vs RST
+    assert_allclose(pps_t.P_s_k * 1e9, pps_t.P_s_HD * 1e9, rtol=1e-3, atol=1e-6)
+    assert_allclose(pps_t.P_s_k * 1e9, pps_t.P_s_RST * 1e9, rtol=1e-2, atol=1e-4)
 
     # oscode vs background
     As_t_oscode = pps_t.P_s_RST[ks_iMpc.size//2]


### PR DESCRIPTION
Add vacuum initial conditions for Hamiltonian diagonalisation and its approximations.

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] My code is PEP8 compliant (`flake8 --max-line-length 99 primpy tests`).
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `anesthetic/__version__.py`.
