### PR TITLE
Set spectral index `n_s` (instead of `N_star`) for flat universes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.11.0
+:Version: 2.12.0
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,3 +1,3 @@
 """Version file for primpy."""
 
-__version__ = '2.11.0'
+__version__ = '2.12.0'

--- a/tests/test_inflation.py
+++ b/tests/test_inflation.py
@@ -5,7 +5,7 @@ from pytest import approx
 from scipy.interpolate import interp1d
 import numpy as np
 from numpy.testing import assert_allclose
-from primpy.exceptionhandling import InflationEndWarning, InsufficientInflationError
+from primpy.exceptionhandling import InflationEndWarning, InsufficientInflationError, PrimpyError
 from primpy.units import Mpc_m, lp_m
 from primpy.parameters import K_STAR
 from primpy.potentials import QuadraticPotential, StarobinskyPotential
@@ -353,6 +353,16 @@ def test_sol_time_efolds(K):
     for o in range(1, 4):
         assert_allclose(bist.P_s_approx(k, 'ARBDS', o), bisn.P_s_approx(k, 'ARBDS', o), rtol=1e-4)
         assert_allclose(bist.P_t_approx(k, 'ARBDS', o), bisn.P_t_approx(k, 'ARBDS', o), rtol=1e-4)
+
+    # set n_s
+    if K == 0:
+        bist.set_ns(0.96, N_star_min=20, N_star_max=65)
+        bisn.set_ns(0.96, N_star_min=20, N_star_max=65)
+        assert bist.n_s == approx(0.96)
+        assert bisn.n_s == approx(0.96)
+    else:
+        with pytest.raises(PrimpyError):
+            bist.set_ns(0.96)
 
     # reheating
     bist.calibrate_scale_factor(calibration_method='reheating', h=h, delta_reh=2, w_reh=0)


### PR DESCRIPTION
This PR creates a post-processing method for setting a desired scalar spectral index $n_s$ in place of the e-folds $N_\ast$ of inflation after horizon crossing of the pivot scale. For flat universes there is a one-to-one correspondence between the two that allows us to do this.

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] My code is PEP8 compliant (`flake8 --max-line-length 99 primpy tests`).
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `anesthetic/__version__.py`.
