### PR TITLE
Wrapper for use with Cobaya

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.12.0
+:Version: 2.13.0
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/cobaya_wrapper/feature_pps.py
+++ b/cobaya_wrapper/feature_pps.py
@@ -1,0 +1,177 @@
+"""Power-law primordial power spectrum (PPS) with features for use with Cobaya."""
+import numpy as np
+from cobaya_wrapper.powerlaw_pps import (ExternalPrimordialPowerSpectrum,
+                                         power_law_primordial_scalar_pk,
+                                         power_law_primordial_tensor_pk)
+
+
+def cutoff(ks, k_cut, s_cut):
+    return np.exp(-(ks/k_cut)**s_cut)
+
+
+def log_oscillations(ks, A_log, w_log, p_log, k_pivot):
+    lnk = np.log(ks / k_pivot)
+    return A_log * np.cos(w_log * lnk + 2*np.pi * p_log)
+
+
+def lin_oscillations(ks, A_lin, w_lin, p_lin, k_pivot):
+    lnk = ks / k_pivot
+    return A_lin * np.cos(w_lin * lnk + 2*np.pi * p_lin)
+
+
+class LogOscillationPPS(ExternalPrimordialPowerSpectrum):
+
+    def get_can_support_params(self):
+        return ['A_s', 'n_s', 'n_run', 'n_runrun',
+                'A_t', 'n_t', 'n_t_run', 'r',
+                'A_log', 'w_log', 'p_log']
+
+    def calculate(self, state, want_derived=True, **params_values_dict):
+        A_s = params_values_dict.get('A_s', None)
+        n_s = params_values_dict.get('n_s', 1)
+        n_run = params_values_dict.get('n_run', 0)
+        n_runrun = params_values_dict.get('n_runrun', 0)
+        A_t = params_values_dict.get('A_t', 0)
+        n_t = params_values_dict.get('n_t', None)
+        n_t_run = params_values_dict.get('n_t_run', None)
+        r = params_values_dict.get('r', A_t/A_s)
+        A_log = params_values_dict.get('A_log', 0)
+        w_log = params_values_dict.get('w_log', None)
+        p_log = params_values_dict.get('p_log', None)
+
+        if n_t is None:
+            # set from inflationary consistency
+            if n_t_run:
+                raise Exception('n_t_run set but using inflation consistency (n_t=None)')
+            n_t = - r / 8.0 * (2.0 - n_s - r / 8.0)
+            n_t_run = r / 8.0 * (r / 8.0 + n_s - 1)
+        if A_t > 0:
+            if r != A_t / A_s:
+                raise Exception("mismatch between `r` and `A_t/A_s`")
+        elif r > 0:
+            A_t = r * A_s
+
+        Pks0 = power_law_primordial_scalar_pk(self.ks, A_s, n_s, n_run, n_runrun, self.k_pivot)
+        Pkt0 = power_law_primordial_tensor_pk(self.ks, A_t, n_t, n_t_run, self.k_pivot)
+        logosc_Pk = log_oscillations(self.ks, A_log, w_log, p_log, self.k_pivot)
+        Pks = Pks0 * (1 + logosc_Pk)
+        Pkt = Pkt0 * (1 + logosc_Pk)
+        state['primordial_scalar_pk'] = {'kmin': self.kmin,
+                                         'kmax': self.kmax,
+                                         'Pk': Pks,
+                                         'log_regular': True}
+        state['primordial_tensor_pk'] = {'kmin': self.kmin,
+                                         'kmax': self.kmax,
+                                         'Pk': Pkt,
+                                         'log_regular': True}
+
+    def get_primordial_scalar_pk(self):
+        return self.current_state['primordial_scalar_pk']
+
+    def get_primordial_tensor_pk(self):
+        return self.current_state['primordial_tensor_pk']
+
+
+class LinOscillationPPS(ExternalPrimordialPowerSpectrum):
+
+    def get_can_support_params(self):
+        return ['A_s', 'n_s', 'n_run', 'n_runrun',
+                'A_t', 'n_t', 'n_t_run', 'r',
+                'A_lin', 'w_lin', 'p_lin']
+
+    def calculate(self, state, want_derived=True, **params_values_dict):
+        A_s = params_values_dict.get('A_s', None)
+        n_s = params_values_dict.get('n_s', 1)
+        n_run = params_values_dict.get('n_run', 0)
+        n_runrun = params_values_dict.get('n_runrun', 0)
+        A_t = params_values_dict.get('A_t', 0)
+        n_t = params_values_dict.get('n_t', None)
+        n_t_run = params_values_dict.get('n_t_run', None)
+        r = params_values_dict.get('r', A_t/A_s)
+        A_lin = params_values_dict.get('A_lin', 0)
+        w_lin = params_values_dict.get('w_lin', None)
+        p_lin = params_values_dict.get('p_lin', None)
+
+        if n_t is None:
+            # set from inflationary consistency
+            if n_t_run:
+                raise Exception('n_t_run set but using inflation consistency (n_t=None)')
+            n_t = - r / 8.0 * (2.0 - n_s - r / 8.0)
+            n_t_run = r / 8.0 * (r / 8.0 + n_s - 1)
+        if A_t > 0:
+            if r != A_t / A_s:
+                raise Exception("mismatch between `r` and `A_t/A_s`")
+        elif r > 0:
+            A_t = r * A_s
+
+        Pks0 = power_law_primordial_scalar_pk(self.ks, A_s, n_s, n_run, n_runrun, self.k_pivot)
+        Pkt0 = power_law_primordial_tensor_pk(self.ks, A_t, n_t, n_t_run, self.k_pivot)
+        linosc_Pk = lin_oscillations(self.ks, A_lin, w_lin, p_lin, self.k_pivot)
+        Pks = Pks0 * (1 + linosc_Pk)
+        Pkt = Pkt0 * (1 + linosc_Pk)
+        state['primordial_scalar_pk'] = {'kmin': self.kmin,
+                                         'kmax': self.kmax,
+                                         'Pk': Pks,
+                                         'log_regular': True}
+        state['primordial_tensor_pk'] = {'kmin': self.kmin,
+                                         'kmax': self.kmax,
+                                         'Pk': Pkt,
+                                         'log_regular': True}
+
+    def get_primordial_scalar_pk(self):
+        return self.current_state['primordial_scalar_pk']
+
+    def get_primordial_tensor_pk(self):
+        return self.current_state['primordial_tensor_pk']
+
+
+class CutoffPPS(ExternalPrimordialPowerSpectrum):
+
+    def get_can_support_params(self):
+        return ['A_s', 'n_s', 'n_run', 'n_runrun',
+                'A_t', 'n_t', 'n_t_run', 'r',
+                'k_cut', 's_cut']
+
+    def calculate(self, state, want_derived=True, **params_values_dict):
+        A_s = params_values_dict.get('A_s', None)
+        n_s = params_values_dict.get('n_s', 1)
+        n_run = params_values_dict.get('n_run', 0)
+        n_runrun = params_values_dict.get('n_runrun', 0)
+        A_t = params_values_dict.get('A_t', 0)
+        n_t = params_values_dict.get('n_t', None)
+        n_t_run = params_values_dict.get('n_t_run', None)
+        r = params_values_dict.get('r', A_t/A_s)
+        k_cut = params_values_dict.get('k_cut', 1e-3)
+        s_cut = params_values_dict.get('s_cut', 2)
+
+        if n_t is None:
+            # set from inflationary consistency
+            if n_t_run:
+                raise Exception('n_t_run set but using inflation consistency (n_t=None)')
+            n_t = - r / 8.0 * (2.0 - n_s - r / 8.0)
+            n_t_run = r / 8.0 * (r / 8.0 + n_s - 1)
+        if A_t > 0:
+            if r != A_t / A_s:
+                raise Exception("mismatch between `r` and `A_t/A_s`")
+        elif r > 0:
+            A_t = r * A_s
+
+        Pks0 = power_law_primordial_scalar_pk(self.ks, A_s, n_s, n_run, n_runrun, self.k_pivot)
+        Pkt0 = power_law_primordial_tensor_pk(self.ks, A_t, n_t, n_t_run, self.k_pivot)
+        cutoff_Pk = cutoff(self.ks, k_cut, s_cut)
+        Pks = Pks0 * (1 - cutoff_Pk)
+        Pkt = Pkt0 * (1 - cutoff_Pk)
+        state['primordial_scalar_pk'] = {'kmin': self.kmin,
+                                         'kmax': self.kmax,
+                                         'Pk': Pks,
+                                         'log_regular': True}
+        state['primordial_tensor_pk'] = {'kmin': self.kmin,
+                                         'kmax': self.kmax,
+                                         'Pk': Pkt,
+                                         'log_regular': True}
+
+    def get_primordial_scalar_pk(self):
+        return self.current_state['primordial_scalar_pk']
+
+    def get_primordial_tensor_pk(self):
+        return self.current_state['primordial_tensor_pk']

--- a/cobaya_wrapper/powerlaw_pps.py
+++ b/cobaya_wrapper/powerlaw_pps.py
@@ -1,0 +1,75 @@
+"""Power-law primordial power spectrum (PPS) for use with Cobaya."""
+import numpy as np
+from cobaya.theory import Theory
+from primpy.parameters import K_STAR
+
+
+def power_law_primordial_scalar_pk(ks, A_s, n_s, n_run, n_runrun, k_pivot):
+    lnk = np.log(ks / k_pivot)
+    return A_s * np.exp((n_s - 1) * lnk + n_run / 2 * lnk**2 + n_runrun / 6 * lnk**3)
+
+
+def power_law_primordial_tensor_pk(ks, A_t, n_t, n_t_run, k_pivot):
+    lnk = np.log(ks / k_pivot)
+    return A_t * np.exp(n_t * lnk + n_t_run / 2 * lnk**2)
+
+
+class ExternalPrimordialPowerSpectrum(Theory):
+    k_pivot = K_STAR
+
+    def initialize(self):
+        # need to provide valid results at wide k range, any that might be used
+        super().initialize()
+        self.kmin = 5e-7
+        self.kmax = 5e1
+        logkmin = np.log10(self.kmin)
+        logkmax = np.log10(self.kmax)
+        num_k = int((logkmax-logkmin) * 100 + 1)
+        self.ks = np.logspace(logkmin, logkmax, num_k)
+
+
+class PowerLawPPS(ExternalPrimordialPowerSpectrum):
+
+    # params = {'A_s': None, 'n_s': None, 'n_run': None, 'n_runrun': None,
+    #           'A_t': None, 'n_t': None, 'n_t_run': None, 'r': None}
+
+    def get_can_support_params(self):
+        return ['A_s', 'n_s', 'n_run', 'n_runrun', 'A_t', 'n_t', 'n_t_run', 'r']
+
+    def calculate(self, state, want_derived=True, **params_values_dict):
+        A_s = params_values_dict.get('A_s', None)
+        n_s = params_values_dict.get('n_s', 1)
+        n_run = params_values_dict.get('n_run', 0)
+        n_runrun = params_values_dict.get('n_runrun', 0)
+        A_t = params_values_dict.get('A_t', 0)
+        n_t = params_values_dict.get('n_t', None)
+        n_t_run = params_values_dict.get('n_t_run', None)
+        r = params_values_dict.get('r', A_t/A_s)
+        if n_t is None:
+            # set from inflationary consistency
+            if n_t_run:
+                raise Exception('n_t_run set but using inflation consistency (n_t=None)')
+            n_t = - r / 8.0 * (2.0 - n_s - r / 8.0)
+            n_t_run = r / 8.0 * (r / 8.0 + n_s - 1)
+        if A_t > 0:
+            if r != A_t / A_s:
+                raise Exception("mismatch between `r` and `A_t/A_s`")
+        elif r > 0:
+            A_t = r * A_s
+
+        Pks = power_law_primordial_scalar_pk(self.ks, A_s, n_s, n_run, n_runrun, self.k_pivot)
+        Pkt = power_law_primordial_tensor_pk(self.ks, A_t, n_t, n_t_run, self.k_pivot)
+        state['primordial_scalar_pk'] = {'kmin': self.kmin,
+                                         'kmax': self.kmax,
+                                         'Pk': Pks,
+                                         'log_regular': True}
+        state['primordial_tensor_pk'] = {'kmin': self.kmin,
+                                         'kmax': self.kmax,
+                                         'Pk': Pkt,
+                                         'log_regular': True}
+
+    def get_primordial_scalar_pk(self):
+        return self.current_state['primordial_scalar_pk']
+
+    def get_primordial_tensor_pk(self):
+        return self.current_state['primordial_tensor_pk']

--- a/cobaya_wrapper/slowroll_pps.py
+++ b/cobaya_wrapper/slowroll_pps.py
@@ -1,0 +1,86 @@
+"""Slow-roll inflationary primordial power spectrum (PPS) for use with Cobaya."""
+import numpy as np
+from cobaya_wrapper.powerlaw_pps import ExternalPrimordialPowerSpectrum
+from primpy.exceptionhandling import PrimpyError
+import primpy.potentials as pp
+from primpy.time.inflation import InflationEquationsT as InflationEquations
+from primpy.events import InflationEvent
+from primpy.initialconditions import SlowRollIC
+from primpy.solver import solve
+
+
+class SlowRollPPS(ExternalPrimordialPowerSpectrum):
+
+    def initialize(self):
+        super().initialize()
+        self.Pot = pp.InflationaryPotential
+
+    def get_can_support_params(self):
+        return {'A_s', 'n_s', 'N_star', 'rho_reh_GeV'}
+
+    def get_can_provide_params(self):
+        return {'N_star',  # 'phi_star', 'V_star', 'H_star',
+                'N_end', 'phi_end', 'V_end', 'H_end',
+                'N_reh', 'w_reh', 'DeltaN_reh',
+                'A_s', 'n_s', 'n_run', 'n_runrun', 'A_t', 'n_t', 'r'}
+
+    def calculate(self, state, want_derived=True, **params_values_dict):
+        N_star = params_values_dict.get('N_star', 90)
+        A_s = params_values_dict.get('A_s')
+        n_s = params_values_dict.get('n_s')
+        rho_reh_GeV = params_values_dict.get('rho_reh_GeV')
+
+        atol = 1e-14
+        rtol = 1e-6
+        K = 0
+        t_eval = np.logspace(5, 8, (8-5)*1000+1)
+        Lambda, phi_star, N_star = self.Pot.sr_As2Lambda(A_s=A_s, N_star=N_star, phi_star=None)
+        for i in range(11):
+            pot = self.Pot(Lambda=Lambda)
+            eq = InflationEquations(K=K, potential=pot, track_eta=False)
+            ev = [InflationEvent(eq, +1, terminal=False),  # records inflation start
+                  InflationEvent(eq, -1, terminal=True)]   # records inflation end
+            ic = SlowRollIC(equations=eq, phi_i=phi_star*1.1, N_i=0, t_i=t_eval[0])
+            b = solve(ic=ic, events=ev, t_eval=t_eval,
+                      atol=1e-18, rtol=2.22045e-14, method='DOP853')
+            b.calibrate_scale_factor(N_star=N_star, rho_reh_GeV=rho_reh_GeV)
+            if n_s is not None:
+                b.set_ns(n_s=n_s, rho_reh_GeV=rho_reh_GeV)
+            # check whether the target A_s is met
+            if abs(b.A_s - A_s) < atol + rtol * A_s:
+                break  # when the target is met, exit the loop
+            elif i < 10:
+                # when the target is not met, use the scaling relations between
+                # A_s and Lambda to predict a new Lambda
+                Lambda = (A_s / b.A_s)**(1 / 4) * Lambda
+            else:
+                raise PrimpyError("`A_s` shooting failed.")
+        if b.w_reh <= -1/3 or b.w_reh >= 1 or b.DeltaN_reh < 0:
+            raise PrimpyError(f"Unrealistic reheating scenario with w_reh={b.w_reh} and "
+                              f"DeltaN_reh={b.DeltaN_reh}.")
+        Pks = b.P_s_approx(self.ks)
+        Pkt = b.P_t_approx(self.ks)
+        state['primordial_scalar_pk'] = {'kmin': self.kmin,
+                                         'kmax': self.kmax,
+                                         'Pk': Pks,
+                                         'log_regular': True}
+        state['primordial_tensor_pk'] = {'kmin': self.kmin,
+                                         'kmax': self.kmax,
+                                         'Pk': Pkt,
+                                         'log_regular': True}
+        derived_params = self.get_can_provide_params()
+        state['derived'] = {derived_param: getattr(b, derived_param)
+                            for derived_param in derived_params}
+
+    def get_primordial_scalar_pk(self):
+        return self.current_state['primordial_scalar_pk']
+
+    def get_primordial_tensor_pk(self):
+        return self.current_state['primordial_tensor_pk']
+
+
+class StarobinskySlowRollPPS(SlowRollPPS):
+
+    def initialize(self):
+        super().initialize()
+        self.Pot = pp.StarobinskyPotential

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,3 +1,3 @@
 """Version file for primpy."""
 
-__version__ = '2.12.0'
+__version__ = '2.13.0'

--- a/tests/test_inflation.py
+++ b/tests/test_inflation.py
@@ -365,8 +365,8 @@ def test_sol_time_efolds(K):
             bist.set_ns(0.96)
 
     # reheating
-    bist.calibrate_scale_factor(calibration_method='reheating', h=h, delta_reh=2, w_reh=0)
-    bisn.calibrate_scale_factor(calibration_method='reheating', h=h, delta_reh=2, w_reh=0)
+    bist.calibrate_scale_factor(calibration_method='reheating', h=h, DeltaN_reh=2, w_reh=0)
+    bisn.calibrate_scale_factor(calibration_method='reheating', h=h, DeltaN_reh=2, w_reh=0)
     assert bist.N_star == approx(bisn.N_star, rel=1e-5)
     assert bist.N_dagg == approx(bisn.N_dagg, rel=1e-5)
     assert bist.A_s == approx(bisn.A_s, rel=1e-8)
@@ -401,9 +401,9 @@ def test_sol_time_efolds(K):
 
 
 @pytest.mark.parametrize('K', [-1, 0, +1])
-@pytest.mark.parametrize('delta_reh', [0, 5])
+@pytest.mark.parametrize('DeltaN_reh', [0, 5])
 @pytest.mark.parametrize('w_reh', [-1/3, 0, 1/3, 1])
-def test_reheating(K, delta_reh, w_reh):
+def test_reheating(K, DeltaN_reh, w_reh):
     pot = StarobinskyPotential(Lambda=3.3e-3)
     N_i = 14
     phi_i = 6
@@ -420,9 +420,9 @@ def test_reheating(K, delta_reh, w_reh):
     bist = solve(ic=ic_t, events=ev_t, dense_output=True, method='DOP853', rtol=1e-12)
     bisn = solve(ic=ic_N, events=ev_N, dense_output=True, method='DOP853', rtol=1e-12)
     bist.calibrate_scale_factor(calibration_method='reheating', h=h,
-                                delta_reh=delta_reh, w_reh=w_reh)
+                                DeltaN_reh=DeltaN_reh, w_reh=w_reh)
     bisn.calibrate_scale_factor(calibration_method='reheating', h=h,
-                                delta_reh=delta_reh, w_reh=w_reh)
+                                DeltaN_reh=DeltaN_reh, w_reh=w_reh)
     assert bist.N_star == approx(bisn.N_star, rel=1e-5)
     assert bist.N_dagg == approx(bisn.N_dagg, rel=1e-5)
     assert bist.N_reh == approx(bisn.N_reh, rel=1e-5)
@@ -447,7 +447,7 @@ def test_derived_reheating(K, rho_reh_GeV):
     assert bist.rho_reh_GeV == rho_reh_GeV
     assert bist.N_end < bist.N_reh
     assert -1/3 <= bist.w_reh <= 1
-    assert bist.delta_reh >= 0
+    assert bist.DeltaN_reh >= 0
 
 
 def nan_inflation_end(background_sol):
@@ -507,7 +507,7 @@ def test_Ncross_not_during_inflation(K, Eq):
     else:
         assert np.log(K_STAR) < np.min(b_sol.logk)
     with pytest.raises(InsufficientInflationError):
-        b_sol.calibrate_scale_factor(calibration_method='reheating', h=h, delta_reh=5, w_reh=0)
+        b_sol.calibrate_scale_factor(calibration_method='reheating', h=h, DeltaN_reh=5, w_reh=0)
     if K == 0:
         assert b_sol._logaH_star < b_sol._logaH_beg
     else:
@@ -537,13 +537,13 @@ def test_calibration_input_errors():
     with pytest.raises(ValueError):
         b_sol.calibrate_scale_factor(N_star=-N_star)
     with pytest.raises(ValueError):
-        b_sol.calibrate_scale_factor(calibration_method='reheating', w_reh=0, delta_reh=-5)
+        b_sol.calibrate_scale_factor(calibration_method='reheating', w_reh=0, DeltaN_reh=-5)
     with pytest.raises(ValueError):
-        b_sol.calibrate_scale_factor(calibration_method='reheating', w_reh=-1, delta_reh=5)
+        b_sol.calibrate_scale_factor(calibration_method='reheating', w_reh=-1, DeltaN_reh=5)
     with pytest.raises(ValueError):
-        b_sol.calibrate_scale_factor(calibration_method='reheating', w_reh=0, delta_reh=None)
+        b_sol.calibrate_scale_factor(calibration_method='reheating', w_reh=0, DeltaN_reh=None)
     with pytest.raises(ValueError):
-        b_sol.calibrate_scale_factor(calibration_method='reheating', w_reh=None, delta_reh=5)
+        b_sol.calibrate_scale_factor(calibration_method='reheating', w_reh=None, DeltaN_reh=5)
     with pytest.raises(ValueError):
         b_sol.calibrate_scale_factor(background=b, N_star=None)
     with pytest.raises(ValueError):
@@ -573,14 +573,14 @@ def test_calibration_input_errors():
         b_sol.calibrate_scale_factor(h=h, Omega_K0=-Omega_K0)
     with pytest.raises(ValueError):  # Omega_K0 should be None for calibration_method='reheating'
         b_sol.calibrate_scale_factor(calibration_method='reheating', h=h, Omega_K0=Omega_K0)
-    with pytest.raises(ValueError):  # negative delta_reh
-        b_sol.calibrate_scale_factor(calibration_method='reheating', h=h, w_reh=0, delta_reh=-5)
+    with pytest.raises(ValueError):  # negative DeltaN_reh
+        b_sol.calibrate_scale_factor(calibration_method='reheating', h=h, w_reh=0, DeltaN_reh=-5)
     with pytest.raises(ValueError):  # w_reh < -1/3
-        b_sol.calibrate_scale_factor(calibration_method='reheating', h=h, w_reh=-1, delta_reh=5)
-    with pytest.raises(ValueError):  # w_reh provided but delta_reh missing
-        b_sol.calibrate_scale_factor(calibration_method='reheating', h=h, w_reh=0, delta_reh=None)
-    with pytest.raises(ValueError):  # delta_reh provided but w_reh missing
-        b_sol.calibrate_scale_factor(calibration_method='reheating', h=h, w_reh=None, delta_reh=5)
+        b_sol.calibrate_scale_factor(calibration_method='reheating', h=h, w_reh=-1, DeltaN_reh=5)
+    with pytest.raises(ValueError):  # w_reh provided but DeltaN_reh missing
+        b_sol.calibrate_scale_factor(calibration_method='reheating', h=h, w_reh=0, DeltaN_reh=None)
+    with pytest.raises(ValueError):  # DeltaN_reh provided but w_reh missing
+        b_sol.calibrate_scale_factor(calibration_method='reheating', h=h, w_reh=None, DeltaN_reh=5)
     with pytest.raises(NotImplementedError):  # non-existent calibration_method
         b_sol.calibrate_scale_factor(calibration_method='spam', h=h)
 


### PR DESCRIPTION
Provides some python files that provide external primordial power spectra that can be called from a Cobaya yaml file.

# Checklist:

- [ ] I have performed a self-review of my own code.
- [x] My code is PEP8 compliant (`flake8 --max-line-length 99 primpy tests`).
- [ ] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
- [ ] New and existing unit tests pass locally with my changes (`python -m pytest`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `anesthetic/__version__.py`.
