### PR TITLE
Fix corner cases for slowroll pps cobaya wrapper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.13.1
+:Version: 2.13.2
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/cobaya_wrapper/powerlaw_pps.py
+++ b/cobaya_wrapper/powerlaw_pps.py
@@ -2,6 +2,7 @@
 import numpy as np
 from cobaya.theory import Theory
 from primpy.parameters import K_STAR
+from primpy.__version__ import __version__
 
 
 def power_law_primordial_scalar_pk(ks, A_s, n_s, n_run, n_runrun, k_pivot):
@@ -20,6 +21,7 @@ class ExternalPrimordialPowerSpectrum(Theory):
     def initialize(self):
         # need to provide valid results at wide k range, any that might be used
         super().initialize()
+        self.mpi_info(f"Using `primpy` module with version {__version__}.")
         self.kmin = 5e-7
         self.kmax = 5e1
         logkmin = np.log10(self.kmin)

--- a/cobaya_wrapper/slowroll_pps.py
+++ b/cobaya_wrapper/slowroll_pps.py
@@ -25,7 +25,7 @@ class SlowRollPPS(ExternalPrimordialPowerSpectrum):
                 'A_s', 'n_s', 'n_run', 'n_runrun', 'A_t', 'n_t', 'r'}
 
     def calculate(self, state, want_derived=True, **params_values_dict):
-        N_star = params_values_dict.get('N_star', 90)
+        N_star = params_values_dict.get('N_star', 75)
         A_s = params_values_dict.get('A_s')
         n_s = params_values_dict.get('n_s')
         rho_reh_GeV = params_values_dict.get('rho_reh_GeV')
@@ -40,20 +40,25 @@ class SlowRollPPS(ExternalPrimordialPowerSpectrum):
         atol = 1e-14
         rtol = 1e-6
         K = 0
-        t_eval = np.logspace(5, 8, (8-5)*1000+1)
-        Lambda, phi_star, N_star = self.Pot.sr_As2Lambda(A_s=A_s, N_star=N_star, phi_star=None,
-                                                         **pot_kwargs)
+        t_eval = np.logspace(5, 12, (12 - 5) * 1000 + 1)
+        Lambda, phi_star, _ = self.Pot.sr_As2Lambda(A_s=A_s, N_star=N_star+10, phi_star=None,
+                                                    **pot_kwargs)
+        if 'phi0' in pot_kwargs and phi_star >= phi0:
+            phi_star = 0.999 * phi0
         for i in range(11):
             pot = self.Pot(Lambda=Lambda, **pot_kwargs)
             eq = InflationEquations(K=K, potential=pot, track_eta=False)
             ev = [InflationEvent(eq, +1, terminal=False),  # records inflation start
                   InflationEvent(eq, -1, terminal=True)]   # records inflation end
-            ic = SlowRollIC(equations=eq, phi_i=phi_star*1.1, N_i=0, t_i=t_eval[0])
+            ic = SlowRollIC(equations=eq, phi_i=phi_star, N_i=0, t_i=t_eval[0])
             b = solve(ic=ic, events=ev, t_eval=t_eval,
                       atol=1e-18, rtol=2.22045e-14, method='DOP853')
+            if not b.success:
+                raise StepSizeError(b.message)
+            N_star = N_star if n_s is None else min(N_star, b.N_tot-0.1)
             b.calibrate_scale_factor(N_star=N_star, rho_reh_GeV=rho_reh_GeV)
             if n_s is not None:
-                b.set_ns(n_s=n_s, rho_reh_GeV=rho_reh_GeV)
+                b.set_ns(n_s=n_s, rho_reh_GeV=rho_reh_GeV, N_star_min=20, N_star_max=min(75, b.N_tot-0.1))
             # check whether the target A_s is met
             if abs(b.A_s - A_s) < atol + rtol * A_s:
                 break  # when the target is met, exit the loop
@@ -64,8 +69,8 @@ class SlowRollPPS(ExternalPrimordialPowerSpectrum):
             else:
                 raise PrimpyError("`A_s` shooting failed.")
         if b.w_reh <= -1/3 or b.w_reh >= 1 or b.DeltaN_reh < 0:
-            raise PrimpyError(f"Unrealistic reheating scenario with w_reh={b.w_reh} and "
-                              f"DeltaN_reh={b.DeltaN_reh}.")
+            raise PrimpyError(f"Unrealistic reheating scenario with w_reh={b.w_reh}, "
+                              f"DeltaN_reh={b.DeltaN_reh}, and N_star={b.N_star}.")
         Pks = b.P_s_approx(self.ks)
         Pkt = b.P_t_approx(self.ks)
         state['primordial_scalar_pk'] = {'kmin': self.kmin,
@@ -122,14 +127,14 @@ class NaturalSlowRollPPS(SlowRollPPS):
         self.Pot = pp.NaturalPotential
 
 
-class DoubleWell2PPS(SlowRollPPS):
+class DoubleWell2SlowRollPPS(SlowRollPPS):
 
     def initialize(self):
         super().initialize()
         self.Pot = pp.DoubleWell2Potential
 
 
-class DoubleWell4PPS(SlowRollPPS):
+class DoubleWell4SlowRollPPS(SlowRollPPS):
 
     def initialize(self):
         super().initialize()

--- a/cobaya_wrapper/slowroll_pps.py
+++ b/cobaya_wrapper/slowroll_pps.py
@@ -1,7 +1,7 @@
 """Slow-roll inflationary primordial power spectrum (PPS) for use with Cobaya."""
 import numpy as np
 from cobaya_wrapper.powerlaw_pps import ExternalPrimordialPowerSpectrum
-from primpy.exceptionhandling import PrimpyError
+from primpy.exceptionhandling import PrimpyError, StepSizeError
 import primpy.potentials as pp
 from primpy.time.inflation import InflationEquationsT as InflationEquations
 from primpy.events import InflationEvent
@@ -58,7 +58,8 @@ class SlowRollPPS(ExternalPrimordialPowerSpectrum):
             N_star = N_star if n_s is None else min(N_star, b.N_tot-0.1)
             b.calibrate_scale_factor(N_star=N_star, rho_reh_GeV=rho_reh_GeV)
             if n_s is not None:
-                b.set_ns(n_s=n_s, rho_reh_GeV=rho_reh_GeV, N_star_min=20, N_star_max=min(75, b.N_tot-0.1))
+                b.set_ns(n_s=n_s, rho_reh_GeV=rho_reh_GeV,
+                         N_star_min=20, N_star_max=min(75, b.N_tot-0.1))
             # check whether the target A_s is met
             if abs(b.A_s - A_s) < atol + rtol * A_s:
                 break  # when the target is met, exit the loop

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,3 +1,3 @@
 """Version file for primpy."""
 
-__version__ = '2.13.1'
+__version__ = '2.13.2'

--- a/tests/test_inflation.py
+++ b/tests/test_inflation.py
@@ -360,6 +360,12 @@ def test_sol_time_efolds(K):
         bisn.set_ns(0.96, N_star_min=20, N_star_max=65)
         assert bist.n_s == approx(0.96)
         assert bisn.n_s == approx(0.96)
+        with pytest.raises(PrimpyError, match="Shooting for `n_s=0.91` failed, "
+                                              "required `N_star` probably too small."):
+            bist.set_ns(0.91, N_star_min=60, N_star_max=65)
+        with pytest.raises(PrimpyError, match="Shooting for `n_s=0.99` failed, "
+                                              "potentially higher `N_star` required."):
+            bisn.set_ns(0.99, N_star_min=20, N_star_max=25)
     else:
         with pytest.raises(PrimpyError):
             bist.set_ns(0.96)


### PR DESCRIPTION
Take care of some corner cases related to the $\phi_0$ parameter for natural and double-well inflation, or to $p$ in monomial potentials, or about the shooting for some target $n_\mathrm{s}$ value.

# Checklist:

- [ ] I have performed a self-review of my own code.
- [ ] My code is PEP8 compliant (`flake8 --max-line-length 99 primpy tests`).
- [ ] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
- [ ] New and existing unit tests pass locally with my changes (`python -m pytest`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `anesthetic/__version__.py`.
