### PR TITLE
T-model potential

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: local
+    hooks:
+      - id: flake8
+        name: flake8
+        entry: python -m flake8 --max-line-length 99
+        language: system
+        types: [python]
+        files: "primpy/|tests/|cobaya_wrapper/"
+      - id: pydocstyle
+        name: pydocstyle
+        entry: python -m pydocstyle --convention=numpy
+        language: system
+        types: [python]
+        files: "primpy/"

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.13.2
+:Version: 2.14.0
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -87,8 +87,8 @@ shifting the number of e-folds :math:`N` by a constant.
 .. plot:: :context: close-figs
 
     # slow-roll estimate of amplitude `Lambda` and field value `phi_star` at horizon crossing
-    Lambda, phi_star, N_star = Pot.sr_As2Lambda(A_s=A_s, N_star=N_star, phi_star=None)
-    pot = Pot(Lambda=Lambda)
+    pot = Pot(A_s=A_s, N_star=N_star, phi_star=None)
+    phi_guess = pot.sr_N2phi(N=N_tot)
     eq = InflationEquations(K=K, potential=pot, track_eta=False)
     ev = [UntilNEvent(eq, value=N_end+delta_N_reh),  # decides stopping criterion
           InflationEvent(eq, +1, terminal=False),    # records inflation start
@@ -96,7 +96,7 @@ shifting the number of e-folds :math:`N` by a constant.
 
     # from inflation start forwards in time, optimising to get `N_tot` e-folds of inflation
     ic_fore = ISIC_Nt(equations=eq, N_tot=N_tot, N_i=N_end-N_tot, t_i=t_eval[0],
-                      phi_i_bracket=[phi_star-3, phi_star+3])
+                      phi_i_bracket=[phi_guess-2, phi_guess+2])
     fward = solve(ic=ic_fore, events=ev, t_eval=t_eval)
     # from inflation start backwards in time
     ic_back = InflationStartIC(equations=eq, phi_i=ic_fore.phi_i, N_i=ic_fore.N_i, t_i=t_eval[0],

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,3 +1,3 @@
 """Version file for primpy."""
 
-__version__ = '2.13.2'
+__version__ = '2.14.0'

--- a/primpy/potentials.py
+++ b/primpy/potentials.py
@@ -441,6 +441,9 @@ class QuadraticPotential(MonomialPotential):
     def d3V(self, phi):  # noqa: D102
         return 0
 
+    def d4V(self, phi):  # noqa: D102
+        return 0
+
     def inv_V(self, V):  # noqa: D102
         return np.sqrt(V) / self.Lambda**2
 

--- a/primpy/potentials.py
+++ b/primpy/potentials.py
@@ -596,6 +596,8 @@ class StarobinskyPotential(InflationaryPotential):
             Number of e-folds `N` until end of inflation.
 
         """
+        warn(DeprecationWarning("This method will be removed in future versions, it is superseded "
+                                "by `sr_phi2N`."))
         gamma = StarobinskyPotential.gamma
         phi_end = np.log(1 + np.sqrt(2) * gamma) / gamma  # =~ 0.9402
         return (np.exp(gamma * phi) - np.exp(gamma * phi_end)
@@ -723,6 +725,8 @@ class NaturalPotential(InflationaryPotential):
             Number of e-folds `N` until end of inflation.
 
         """
+        warn(DeprecationWarning("This method will be removed in future versions, it is superseded "
+                                "by `sr_phi2N`."))
         assert np.all(phi < phi0)
         f = phi0 / pi
         return -f**2 * (np.log(1 + 1 / (2 * f**2)) + 2 * np.log(np.cos(phi / (2 * f))))
@@ -887,6 +891,8 @@ class DoubleWell2Potential(DoubleWellPotential):
             Number of e-folds `N` until end of inflation.
 
         """
+        warn(DeprecationWarning("This method will be removed in future versions, it is superseded "
+                                "by `sr_phi2N`."))
         assert np.all(phi_shifted < phi0)
         phi2 = (phi_shifted - phi0)**2
         phi_end2 = 4 + phi0**2 - 2 * np.sqrt(4 + 2 * phi0**2)
@@ -948,6 +954,8 @@ class DoubleWell4Potential(DoubleWellPotential):
             Number of e-folds `N` until end of inflation.
 
         """
+        warn(DeprecationWarning("This method will be removed in future versions, it is superseded "
+                                "by `sr_phi2N`."))
         assert np.all(phi_shifted < phi0)
         phi2 = (phi_shifted - phi0)**2
         phi_end2 = cls.phi_end_squared(phi0=phi0)

--- a/primpy/potentials.py
+++ b/primpy/potentials.py
@@ -114,6 +114,22 @@ class InflationaryPotential(ABC):
         """
 
     @abstractmethod
+    def d4V(self, phi):
+        """Fourth derivative `V''''(phi)` with respect to inflaton `phi`.
+
+        Parameters
+        ----------
+        phi : float or np.ndarray
+            Inflaton field `phi`.
+
+        Returns
+        -------
+        d4V : float or np.ndarray
+            4th derivative of inflationary potential: `V''''(phi)`.
+
+        """
+
+    @abstractmethod
     def inv_V(self, V):
         """Inverse function `phi(V)` with respect to potential `V`.
 

--- a/primpy/potentials.py
+++ b/primpy/potentials.py
@@ -148,11 +148,6 @@ class InflationaryPotential(ABC):
 
     # TODO:
     # @abstractmethod
-    # def sr_phi_end(self):
-    #     """Slow-roll approximation for the inflaton value at the end of inflation."""
-
-    # TODO:
-    # @abstractmethod
     # def sr_n_s(self):
     #     """Slow-roll approximation for the spectral index."""
 
@@ -160,16 +155,6 @@ class InflationaryPotential(ABC):
     # @abstractmethod
     # def sr_n_s(self):
     #     """Slow-roll approximation for the tensor-to-scalar ratio."""
-
-    # TODO:
-    # @abstractmethod
-    # def sr_epsilon(self):
-    #     """Slow-roll potential parameter `epsilon`."""
-
-    # TODO:
-    # @abstractmethod
-    # def sr_eta(self):
-    #     """Slow-roll potential parameter `eta`."""
 
     @abstractmethod
     def get_epsilon_1V(self, phi):

--- a/primpy/potentials.py
+++ b/primpy/potentials.py
@@ -924,87 +924,87 @@ class DoubleWell4Potential(DoubleWellPotential):
 class TmodelPotential(InflationaryPotential):
     """T-model potential: `V(phi) = Lambda**4 * (tanh(phi / (sqrt(6) * alpha)))**(2*p)`."""
 
-    tag = 'tmn'
+    tag = 'tmp'
     name = 'TmodelPotential'
     tex = r'T-model'
     perturbation_ic = (1, 0, 0, 1)
 
     def __init__(self, **pot_kwargs):
-        self.n = pot_kwargs.pop('n')
+        self.p = pot_kwargs.pop('p')
         self.alpha = pot_kwargs.pop('alpha')
         self.s_6_a = np.sqrt(6 * self.alpha)
         super().__init__(**pot_kwargs)
 
     def V(self, phi):  # noqa: D102
         C = np.tanh(phi / self.s_6_a)
-        return self.Lambda**4 * C**(2 * self.n)
+        return self.Lambda**4 * C**(2 * self.p)
 
     def dV(self, phi):  # noqa: D102
-        n = self.n
-        L1 = n * self.Lambda**4 / self.s_6_a
+        p = self.p
+        L1 = p * self.Lambda**4 / self.s_6_a
         C = np.tanh(phi / self.s_6_a)
-        return 2 * L1 * (C**(2*n-1) - C**(2*n+1))
+        return 2 * L1 * (C**(2*p-1) - C**(2*p+1))
 
     def d2V(self, phi):  # noqa: D102
-        n = self.n
-        L2 = 2 * n * self.Lambda**4 / self.s_6_a**2
+        p = self.p
+        L2 = 2 * p * self.Lambda**4 / self.s_6_a**2
         C = np.tanh(phi / self.s_6_a)
-        return L2 * (+ C**(2*n-2) * (2 * n - 1)
-                     - C**(2*n+0) * 4 * n
-                     + C**(2*n+2) * (2 * n + 1))
+        return L2 * (+ C**(2*p-2) * (2 * p - 1)
+                     - C**(2*p+0) * 4 * p
+                     + C**(2*p+2) * (2 * p + 1))
 
     def d3V(self, phi):  # noqa: D102
-        n = self.n
-        L3 = 4 * n * self.Lambda**4 / self.s_6_a**3
+        p = self.p
+        L3 = 4 * p * self.Lambda**4 / self.s_6_a**3
         C = np.tanh(phi / self.s_6_a)
-        return L3 * (+ C**(2*n-3) * (2*n**2 - 3*n + 1)
-                     + C**(2*n-1) * (-6*n**2 + 3*n - 1)
-                     + C**(2*n+1) * (6*n**2 + 3*n + 1)
-                     + C**(2*n+3) * (-2*n**2 - 3*n - 1))
+        return L3 * (+ C**(2*p-3) * (2*p**2 - 3*p + 1)
+                     + C**(2*p-1) * (-6*p**2 + 3*p - 1)
+                     + C**(2*p+1) * (6*p**2 + 3*p + 1)
+                     + C**(2*p+3) * (-2*p**2 - 3*p - 1))
 
     def d4V(self, phi):  # noqa: D102
-        n = self.n
-        L4 = 4 * n * self.Lambda**4 / self.s_6_a**4
+        p = self.p
+        L4 = 4 * p * self.Lambda**4 / self.s_6_a**4
         C = np.tanh(phi / self.s_6_a)
-        return L4 * (+ C**(2*n - 4) * (4*n**3 - 12*n**2 + 11*n - 3)
-                     + C**(2*n - 2) * (-16*n**3 + 24*n**2 - 16*n + 4)
-                     + C**(2*n + 0) * (24 * n**3 + 10 * n)
-                     + C**(2*n + 2) * (-16*n**3 - 24*n**2 - 16*n - 4)
-                     + C**(2*n + 4) * (4*n**3 + 12*n**2 + 11*n + 3))
+        return L4 * (+ C**(2*p - 4) * (4*p**3 - 12*p**2 + 11*p - 3)
+                     + C**(2*p - 2) * (-16*p**3 + 24*p**2 - 16*p + 4)
+                     + C**(2*p + 0) * (24 * p**3 + 10 * p)
+                     + C**(2*p + 2) * (-16*p**3 - 24*p**2 - 16*p - 4)
+                     + C**(2*p + 4) * (4*p**3 + 12*p**2 + 11*p + 3))
 
     def inv_V(self, V):  # noqa: D102
-        n = self.n
-        return self.s_6_a * np.arctanh(V**(1/(2*n)) / self.Lambda**(2/n))
+        p = self.p
+        return self.s_6_a * np.arctanh(V**(1/(2*p)) / self.Lambda**(2/p))
 
     def get_epsilon_1V(self, phi):  # noqa: D102
-        return 8 * self.n**2 / (self.s_6_a**2 * np.sinh(2 * phi / self.s_6_a)**2)
+        return 8 * self.p**2 / (self.s_6_a**2 * np.sinh(2 * phi / self.s_6_a)**2)
 
     def get_epsilon_2V(self, phi):  # noqa: D102
         C = np.tanh(phi / self.s_6_a)
-        return 4 * self.n * (1 - C**4) / (C**2 * self.s_6_a**2)
+        return 4 * self.p * (1 - C**4) / (C**2 * self.s_6_a**2)
 
     def get_epsilon_3V(self, phi):  # noqa: D102
         C = np.tanh(phi / self.s_6_a)
-        return 4 * self.n * (-C**6 + C**4 - C**2 + 1) / (C**2 * self.s_6_a**2 * (C**2 + 1))
+        return 4 * self.p * (-C**6 + C**4 - C**2 + 1) / (C**2 * self.s_6_a**2 * (C**2 + 1))
 
     def get_epsilon_4V(self, phi):  # noqa: D102
         C = np.tanh(phi / self.s_6_a)
-        return (4 * self.n * (-C**10 - C**8 + 4*C**6 - 4*C**4 + C**2 + 1)
+        return (4 * self.p * (-C**10 - C**8 + 4*C**6 - 4*C**4 + C**2 + 1)
                 / (C**2 * self.s_6_a**2 * (C**6 + C**4 + C**2 + 1)))
 
     @cached_property
     def phi_end(self):  # noqa: D102
-        return self.s_6_a/2 * np.arcsinh(2 * np.sqrt(2) * self.n / self.s_6_a)
+        return self.s_6_a/2 * np.arcsinh(2 * np.sqrt(2) * self.p / self.s_6_a)
 
     def sr_phi2N(self, phi):  # noqa: D102
-        n = self.n
+        p = self.p
         s_6_a = self.s_6_a
-        return s_6_a/(8*n) * (s_6_a * np.cosh(2*phi/s_6_a) - np.sqrt(8*n**2 + s_6_a**2))
+        return s_6_a/(8*p) * (s_6_a * np.cosh(2*phi/s_6_a) - np.sqrt(8*p**2 + s_6_a**2))
 
     def sr_N2phi(self, N):  # noqa: D102
-        n = self.n
+        p = self.p
         s_6_a = self.s_6_a
-        return s_6_a / 2 * np.arccosh(8*n/s_6_a**2 * N + np.sqrt(8*n**2+s_6_a**2)/s_6_a)
+        return s_6_a / 2 * np.arccosh(8*p/s_6_a**2 * N + np.sqrt(8*p**2+s_6_a**2)/s_6_a)
 
 
 # TODO:

--- a/primpy/potentials.py
+++ b/primpy/potentials.py
@@ -702,7 +702,7 @@ class StarobinskyPotential(InflationaryPotential):
         g = StarobinskyPotential.gamma
         phi_end = self.phi_end
         return (-2*N*g + phi_end - np.exp(g*phi_end)/g -
-                lambertw(-np.exp(-2*N*g**2) * np.exp(g*phi_end) * np.exp(-np.exp(g*phi_end))) / g)
+                lambertw(-np.exp(-2*N*g**2)*np.exp(g*phi_end)*np.exp(-np.exp(g*phi_end)), -1) / g)
 
     @staticmethod
     def sr_Nstar2ns(N_star):

--- a/primpy/potentials.py
+++ b/primpy/potentials.py
@@ -429,24 +429,19 @@ class QuadraticPotential(MonomialPotential):
             raise ValueError("'mass' was dropped use 'Lambda' instead: Lambda**4=mass**2")
         super().__init__(p=2, **pot_kwargs)
 
-    def V(self, phi):
-        """`V(phi) = Lambda**4 * phi**2`."""
+    def V(self, phi):  # noqa: D102
         return self.Lambda**4 * phi**2
 
-    def dV(self, phi):
-        """`V'(phi) = 2 * Lambda**4 * phi`."""
+    def dV(self, phi):  # noqa: D102
         return 2 * self.Lambda**4 * phi
 
-    def d2V(self, phi):
-        """`V''(phi) = 2 * Lambda**4`."""
+    def d2V(self, phi):  # noqa: D102
         return 2 * self.Lambda**4
 
-    def d3V(self, phi):
-        """`V'''(phi) = 0`."""
+    def d3V(self, phi):  # noqa: D102
         return 0
 
-    def inv_V(self, V):
-        """`phi(V) = sqrt(V) / Lambda**2`."""
+    def inv_V(self, V):  # noqa: D102
         return np.sqrt(V) / self.Lambda**2
 
     @staticmethod
@@ -635,27 +630,22 @@ class StarobinskyPotential(InflationaryPotential):
     def __init__(self, **pot_kwargs):
         super().__init__(**pot_kwargs)
 
-    def V(self, phi):
-        """`V(phi) = Lambda**4 * (1 - exp(-sqrt(2/3) * phi))**2`."""
+    def V(self, phi):  # noqa: D102
         return self.Lambda**4 * (1 - np.exp(-StarobinskyPotential.gamma * phi))**2
 
-    def dV(self, phi):
-        """`V'(phi) = Lambda**4 * 2 * gamma * exp(-2 * gamma * phi) * (-1 + exp(gamma * phi))`."""
+    def dV(self, phi):  # noqa: D102
         gamma = StarobinskyPotential.gamma
         return self.Lambda**4 * 2 * gamma * np.exp(-2 * gamma * phi) * (np.exp(gamma * phi) - 1)
 
-    def d2V(self, phi):
-        """`V''(phi) = Lambda**4 * 2 * gamma**2 * exp(-2*gamma*phi) * (2 - exp(gamma*phi))`."""
+    def d2V(self, phi):  # noqa: D102
         gamma = StarobinskyPotential.gamma
         return self.Lambda**4 * 2 * gamma**2 * np.exp(-2 * gamma * phi) * (2 - np.exp(gamma * phi))
 
-    def d3V(self, phi):
-        """`V'''(phi) = Lambda**4 * 2 * gamma**3 * exp(-2*gamma*phi) * (-4 + exp(gamma*phi))`."""
+    def d3V(self, phi):  # noqa: D102
         gamma = StarobinskyPotential.gamma
         return self.Lambda**4 * 2 * gamma**3 * np.exp(-2 * gamma * phi) * (np.exp(gamma * phi) - 4)
 
-    def inv_V(self, V):
-        """`phi(V) = -np.log(1 - np.sqrt(V) / Lambda**2) / gamma`."""
+    def inv_V(self, V):  # noqa: D102
         return -np.log(1 - np.sqrt(V) / self.Lambda**2) / StarobinskyPotential.gamma
 
     @staticmethod
@@ -771,24 +761,19 @@ class NaturalPotential(InflationaryPotential):
         self.phi0 = pot_kwargs.pop('phi0')
         super().__init__(**pot_kwargs)
 
-    def V(self, phi):
-        """`V(phi) = Lambda**4 * (1 - cos(pi*phi/phi0))`."""
+    def V(self, phi):  # noqa: D102
         return self.Lambda**4 / 2 * (1 - np.cos(pi * phi / self.phi0))
 
-    def dV(self, phi):
-        """`V(phi) = Lambda**4 * sin(pi*phi/phi0) * pi / phi0`."""
+    def dV(self, phi):  # noqa: D102
         return self.Lambda**4 / 2 * np.sin(pi * phi / self.phi0) * pi / self.phi0
 
-    def d2V(self, phi):
-        """`V(phi) = Lambda**4 * cos(pi*phi/phi0) * (pi / phi0)**2`."""
+    def d2V(self, phi):  # noqa: D102
         return self.Lambda**4 / 2 * np.cos(pi * phi / self.phi0) * (pi / self.phi0)**2
 
-    def d3V(self, phi):
-        """`V(phi) = -Lambda**4 * sin(pi*phi/phi0) * (pi / phi0)**3`."""
+    def d3V(self, phi):  # noqa: D102
         return -self.Lambda**4 / 2 * np.sin(pi * phi / self.phi0) * (pi / self.phi0)**3
 
-    def inv_V(self, V):
-        """`phi(V) = arccos(1 - V / Lambda**4) * phi0 / pi`."""
+    def inv_V(self, V):  # noqa: D102
         return np.arccos(1 - 2 * V / self.Lambda**4) * self.phi0 / pi
 
     @staticmethod
@@ -914,45 +899,28 @@ class DoubleWellPotential(InflationaryPotential):
         super().__init__(**pot_kwargs)
         self.prefactor = 2 * self.p * self.Lambda**4
 
-    def V(self, phi):
-        """`V(phi) = Lambda**4 * (1 - (phi/phi0)**p)**2`.
-
-        Double-Well shifted such that left minimum is at zero: phi -> phi-phi0
-        """
+    def V(self, phi):  # noqa: D102
         return self.Lambda**4 * (1 - ((phi - self.phi0) / self.phi0)**self.p)**2
 
-    def dV(self, phi):
-        """`V'(phi) = 2p*Lambda**4 * (-1 + (phi / phi0)**p) * phi**(p - 1) / phi0**p`.
-
-        Double-Well shifted such that left minimum is at zero: phi -> phi-phi0
-        """
+    def dV(self, phi):  # noqa: D102
         p = self.p
         phi0 = self.phi0
         pre = self.prefactor
         return pre * (-1 + ((phi - phi0) / phi0)**p) * (phi - phi0)**(p - 1) / phi0**p
 
-    def d2V(self, phi):
-        """`V''(phi) = 2p*Lambda**4 * (1-p+(2*p-1)*(phi/phi0)**p) * phi**(p-2) / phi0**p`.
-
-        Double-Well shifted such that left minimum is at zero: phi -> phi-phi0
-        """
+    def d2V(self, phi):  # noqa: D102
         p = self.p
         phi0 = self.phi0
         pre = self.prefactor
         return pre * (1 - p + (2 * p - 1) * ((phi-phi0) / phi0)**p) * (phi-phi0)**(p-2) / phi0**p
 
-    def d3V(self, phi):
-        """`V'''(phi) = 2p(p-1)Lambda**4 * (2-p+(4*p-2)*(phi/phi0)**p) * phi**(p-3) / phi0**p`.
-
-        Double-Well shifted such that left minimum is at zero: phi -> phi-phi0
-        """
+    def d3V(self, phi):  # noqa: D102
         p = self.p
         phi0 = self.phi0
         pre = self.prefactor
         return pre * (p-1) * (2 - p + (4*p-2) * ((phi-phi0)/phi0)**p) * (phi-phi0)**(p-3) / phi0**p
 
-    def inv_V(self, V):
-        """`phi(V) = phi0 * (1 - sqrt(V) / Lambda**2)**(1/p)`."""
+    def inv_V(self, V):  # noqa: D102
         return self.phi0 * (1 - np.sqrt(V) / self.Lambda**2)**(1/self.p)
 
     @staticmethod

--- a/primpy/potentials.py
+++ b/primpy/potentials.py
@@ -224,7 +224,38 @@ class InflationaryPotential(ABC):
         """Convert from inflaton field `phi` to e-folds `N` assuming slow-roll approximation."""
 
     def sr_As2Lambda(self, A_s, phi_star, N_star, **pot_kwargs):
-        """Get potential amplitude `Lambda` from PPS amplitude `A_s` assuming slow-roll."""
+        """Get potential amplitude `Lambda` from PPS amplitude `A_s` using slow-roll approximation.
+
+        Find the inflaton amplitude `Lambda` (4th root of potential amplitude)
+        that produces the desired amplitude `A_s` of the primordial power
+        spectrum using the slow-roll approximation.
+
+        Note that either `phi_star` or `N_star` have to be passed as `None`, and will be
+        calculated subsequently from the respective other.
+
+        Parameters
+        ----------
+        A_s : float
+            Target amplitude `A_s` of scalar primordial power spectrum
+            (at the pivot scale `k=0.05 Mpc^{-1}`).
+        phi_star : float
+            Inflaton field value at the time of horizon crossing of the pivot scale.
+        N_star : float
+            Number of e-folds of inflation remaining at the time of horizon crossing of
+            the pivot scale.
+
+        Returns
+        -------
+        Lambda : float
+            Potential amplitude parameter `Lambda` corresponding approximately to `A_s`.
+        phi_star : float
+            Estimated inflaton field value at the time of horizon crossing of the pivot scale,
+            inferred from `N_star`. (Exact if passed as input.)
+        N_star : float
+            Estimated number of e-folds of inflation remaining at the time of horizon crossing of
+            the pivot scale, inferred from `phi_star`. (Exact if passed as input.)
+
+        """
         if N_star is None:
             N_star = self.sr_phi2N(phi_star)
         elif phi_star is None:
@@ -514,8 +545,10 @@ class StarobinskyPotential(InflationaryPotential):
     def sr_N2phi(self, N):  # noqa: D102
         g = StarobinskyPotential.gamma
         phi_end = self.phi_end
-        return (-2*N*g + phi_end - np.exp(g*phi_end)/g -
-                lambertw(-np.exp(-2*N*g**2)*np.exp(g*phi_end)*np.exp(-np.exp(g*phi_end)), -1) / g)
+        return np.real_if_close(
+            -2*N*g + phi_end - np.exp(g*phi_end)/g
+            - lambertw(-np.exp(-2*N*g**2)*np.exp(g*phi_end)*np.exp(-np.exp(g*phi_end)), -1) / g
+        )
 
     @staticmethod
     def sr_Nstar2ns(N_star):

--- a/primpy/potentials.py
+++ b/primpy/potentials.py
@@ -333,46 +333,6 @@ class MonomialPotential(InflationaryPotential):
         p = pot_kwargs.pop('p')
         return p * (16 - r) / (4 * r)
 
-    @staticmethod
-    def sr_As2Lambda(A_s, phi_star, N_star, **pot_kwargs):
-        """Get potential amplitude `Lambda` from PPS amplitude `A_s`.
-
-        Find the inflaton amplitude `Lambda` (4th root of potential amplitude)
-        that produces the desired amplitude `A_s` of the primordial power
-        spectrum using the slow-roll approximation.
-
-        Parameters
-        ----------
-        A_s : float or np.ndarray
-            Amplitude `A_s` of the primordial power spectrum.
-        phi_star : float or None
-            Inflaton value at horizon crossing of the pivot scale.
-        N_star : float or None
-            Number of observable e-folds of inflation `N_star`
-            from horizon crossing till the end of inflation.
-
-        Returns
-        -------
-        Lambda : float or np.ndarray
-            Amplitude parameter `Lambda` for the Monomial potential.
-        phi_star : float
-            Inflaton value at horizon crossing of the pivot scale.
-        N_star: float
-            Number of observable e-folds of inflation `N_star`
-            from horizon crossing till the end of inflation.
-
-        """
-        p = pot_kwargs.pop('p')
-        if N_star is None:
-            N_star = phi_star**2 / (2 * p) - p / 4
-        elif phi_star is None:
-            phi_star = np.sqrt(p / 2 * (4 * N_star + p))
-        else:
-            raise Exception("Need to specify either N_star or phi_star. "
-                            "The respective other should be None.")
-        Lambda = (3 * A_s)**(1/4) * np.sqrt(2 * pi * p) * phi_star**(-1/2-p/4)
-        return Lambda, phi_star, N_star
-
 
 class LinearPotential(MonomialPotential):
     """Linear potential: `V(phi) = Lambda**4 * phi`."""
@@ -400,37 +360,6 @@ class LinearPotential(MonomialPotential):
     @staticmethod
     def sr_r2Nstar(r, **pot_params):  # noqa: D102
         return MonomialPotential.sr_r2Nstar(r=r, p=1)
-
-    @staticmethod
-    def sr_As2Lambda(A_s, phi_star, N_star, **pot_kwargs):
-        """Get potential amplitude `Lambda` from PPS amplitude `A_s`.
-
-        Find the inflaton amplitude `Lambda` (4th root of potential amplitude)
-        that produces the desired amplitude `A_s` of the primordial power
-        spectrum using the slow-roll approximation.
-
-        Parameters
-        ----------
-        A_s : float or np.ndarray
-            Amplitude `A_s` of the primordial power spectrum.
-        phi_star : float or None
-            Inflaton value at horizon crossing of the pivot scale.
-        N_star : float or None
-            Number of observable e-folds of inflation `N_star`
-            from horizon crossing till the end of inflation.
-
-        Returns
-        -------
-        Lambda : float or np.ndarray
-            Amplitude parameter `Lambda` for the Linear potential.
-        phi_star : float
-            Inflaton value at horizon crossing of the pivot scale.
-        N_star: float
-            Number of observable e-folds of inflation `N_star`
-            from horizon crossing till the end of inflation.
-
-        """
-        return MonomialPotential.sr_As2Lambda(A_s, phi_star, N_star, p=1)
 
 
 class QuadraticPotential(MonomialPotential):
@@ -480,45 +409,6 @@ class QuadraticPotential(MonomialPotential):
     def sr_r2Nstar(r, **pot_kwargs):  # noqa: D102
         return MonomialPotential.sr_r2Nstar(r=r, p=2)
 
-    @staticmethod
-    def sr_As2Lambda(A_s, phi_star, N_star, **pot_kwargs):
-        """Get potential amplitude `Lambda` from PPS amplitude `A_s`.
-
-        Find the inflaton mass `m` (i.e. essentially the potential amplitude)
-        that produces the desired amplitude `A_s` of the primordial power
-        spectrum using the slow roll approximation.
-
-        Parameters
-        ----------
-        A_s : float or np.ndarray
-            Amplitude `A_s` of the primordial power spectrum.
-        phi_star : float or None
-            Inflaton value at horizon crossing of the pivot scale.
-        N_star : float or None
-            Number of observable e-folds of inflation `N_star`
-            from horizon crossing till the end of inflation.
-
-        Returns
-        -------
-        Lambda : float or np.ndarray
-            Amplitude parameter `Lambda` for the Quadratic potential (Lambda**2 = mass).
-        phi_star : float
-            Inflaton value at horizon crossing of the pivot scale.
-        N_star: float
-            Number of observable e-folds of inflation `N_star`
-            from horizon crossing till the end of inflation.
-
-        """
-        if N_star is None:
-            N_star = (phi_star**2 - 2) / 4
-        elif phi_star is None:
-            phi_star = np.sqrt(4 * N_star + 2)
-        else:
-            raise Exception("Need to specify either N_star or phi_star. "
-                            "The respective other should be None.")
-        Lambda = 2 * np.sqrt(pi * np.sqrt(6 * A_s)) / phi_star
-        return Lambda, phi_star, N_star
-
 
 class CubicPotential(MonomialPotential):
     """Linear potential: `V(phi) = Lambda**4 * phi`."""
@@ -547,37 +437,6 @@ class CubicPotential(MonomialPotential):
     def sr_r2Nstar(r, **pot_kwargs):  # noqa: D102
         return MonomialPotential.sr_r2Nstar(r=r, p=3)
 
-    @staticmethod
-    def sr_As2Lambda(A_s, phi_star, N_star, **pot_kwargs):
-        """Get potential amplitude `Lambda` from PPS amplitude `A_s`.
-
-        Find the inflaton amplitude `Lambda` (4th root of potential amplitude)
-        that produces the desired amplitude `A_s` of the primordial power
-        spectrum using the slow-roll approximation.
-
-        Parameters
-        ----------
-        A_s : float or np.ndarray
-            Amplitude `A_s` of the primordial power spectrum.
-        phi_star : float or None
-            Inflaton value at horizon crossing of the pivot scale.
-        N_star : float or None
-            Number of observable e-folds of inflation `N_star`
-            from horizon crossing till the end of inflation.
-
-        Returns
-        -------
-        Lambda : float or np.ndarray
-            Amplitude parameter `Lambda` for the Linear potential.
-        phi_star : float
-            Inflaton value at horizon crossing of the pivot scale.
-        N_star: float
-            Number of observable e-folds of inflation `N_star`
-            from horizon crossing till the end of inflation.
-
-        """
-        return MonomialPotential.sr_As2Lambda(A_s, phi_star, N_star, p=3)
-
 
 class QuarticPotential(MonomialPotential):
     """Linear potential: `V(phi) = Lambda**4 * phi`."""
@@ -605,37 +464,6 @@ class QuarticPotential(MonomialPotential):
     @staticmethod
     def sr_r2Nstar(r, **pot_kwargs):  # noqa: D102
         return MonomialPotential.sr_r2Nstar(r=r, p=4)
-
-    @staticmethod
-    def sr_As2Lambda(A_s, phi_star, N_star, **pot_kwargs):
-        """Get potential amplitude `Lambda` from PPS amplitude `A_s`.
-
-        Find the inflaton amplitude `Lambda` (4th root of potential amplitude)
-        that produces the desired amplitude `A_s` of the primordial power
-        spectrum using the slow-roll approximation.
-
-        Parameters
-        ----------
-        A_s : float or np.ndarray
-            Amplitude `A_s` of the primordial power spectrum.
-        phi_star : float or None
-            Inflaton value at horizon crossing of the pivot scale.
-        N_star : float or None
-            Number of observable e-folds of inflation `N_star`
-            from horizon crossing till the end of inflation.
-
-        Returns
-        -------
-        Lambda : float or np.ndarray
-            Amplitude parameter `Lambda` for the Linear potential.
-        phi_star : float
-            Inflaton value at horizon crossing of the pivot scale.
-        N_star: float
-            Number of observable e-folds of inflation `N_star`
-            from horizon crossing till the end of inflation.
-
-        """
-        return MonomialPotential.sr_As2Lambda(A_s, phi_star, N_star, p=4)
 
 
 class StarobinskyPotential(InflationaryPotential):
@@ -754,49 +582,6 @@ class StarobinskyPotential(InflationaryPotential):
         phi_end = np.log(1 + np.sqrt(2) * gamma) / gamma  # =~ 0.9402
         return (np.exp(gamma * phi) - np.exp(gamma * phi_end)
                 - gamma * (phi - phi_end)) / (2 * gamma**2)
-
-    @classmethod
-    def sr_As2Lambda(cls, A_s, phi_star, N_star, **pot_kwargs):
-        """Get potential amplitude `Lambda` from PPS amplitude `A_s`.
-
-        Find the inflaton amplitude `Lambda` (4th root of potential amplitude)
-        that produces the desired amplitude `A_s` of the primordial power
-        spectrum using the slow-roll approximation.
-
-        Parameters
-        ----------
-        A_s : float or np.ndarray
-            Amplitude `A_s` of the primordial power spectrum.
-        phi_star : float or None
-            Inflaton value at horizon crossing of the pivot scale.
-        N_star : float or None
-            Number of observable e-folds of inflation `N_star`
-            from horizon crossing till the end of inflation.
-
-        Returns
-        -------
-        Lambda : float or np.ndarray
-            Amplitude parameter `Lambda` for the Starobinsky potential.
-        phi_star : float
-            Inflaton value at horizon crossing of the pivot scale.
-        N_star : float
-            Number of observable e-folds of inflation `N_star`
-            from horizon crossing till the end of inflation.
-
-        """
-        if N_star is None:
-            N_star = cls.phi2efolds(phi=phi_star)
-        elif phi_star is None:
-            # phi = np.sqrt(3 / 2) * np.log(4 / 3 * N_star + 1)  # insufficient approximation
-            phi_sample = np.linspace(0.95, 20, 100000)  # 0.95 >~ phi_end =~ 0.9402
-            N_sample = cls.phi2efolds(phi=phi_sample)
-            logN2phi = interp1d(np.log(N_sample), phi_sample)
-            phi_star = logN2phi(np.log(N_star))
-        else:
-            raise Exception("Need to specify either N_star or phi_star. "
-                            "The respective other should be None.")
-        Lambda = (2 * A_s)**(1/4) * np.sqrt(pi) / np.sinh(phi_star / np.sqrt(6))
-        return Lambda, phi_star, N_star
 
 
 class NaturalPotential(InflationaryPotential):
@@ -923,54 +708,6 @@ class NaturalPotential(InflationaryPotential):
         assert np.all(phi < phi0)
         f = phi0 / pi
         return -f**2 * (np.log(1 + 1 / (2 * f**2)) + 2 * np.log(np.cos(phi / (2 * f))))
-
-    @classmethod
-    def sr_As2Lambda(cls, A_s, phi_star, N_star, **pot_kwargs):
-        """Get potential amplitude `Lambda` from PPS amplitude `A_s`.
-
-        Find the inflaton amplitude `Lambda` (4th root of potential amplitude)
-        that produces the desired amplitude `A_s` of the primordial power
-        spectrum using the slow-roll approximation.
-
-        Parameters
-        ----------
-        A_s : float or np.ndarray
-            Amplitude `A_s` of the primordial power spectrum.
-        phi_star : float or None
-            Inflaton value at horizon crossing of the pivot scale.
-        N_star : float or None
-            Number of observable e-folds of inflation `N_star`
-            from horizon crossing till the end of inflation.
-
-        Other Parameters
-        ----------------
-        phi0 : float
-            Inflaton distance between local maximum and minima.
-
-        Returns
-        -------
-        Lambda : float or np.ndarray
-            Amplitude parameter `Lambda` for the Natural inflation potential.
-        phi_star : float
-            Inflaton value at horizon crossing of the pivot scale.
-        N_star : float
-            Number of observable e-folds of inflation `N_star`
-            from horizon crossing till the end of inflation.
-
-        """
-        phi0 = pot_kwargs.pop('phi0')
-        f = phi0 / pi
-        if N_star is None:
-            N_star = cls.phi2efolds(phi=phi_star, phi0=phi0)
-        elif phi_star is None:
-            phi_star = 2 * f * np.arccos(np.exp(-N_star / (2*f**2)) / np.sqrt(1 + 1 / (2*f**2)))
-        else:
-            raise Exception("Need to specify either N_star or phi_star. "
-                            "The respective other should be None.")
-        numerator = pi * np.sin(phi_star / f)
-        denominator = f * np.sin(phi_star / (2 * f))**3
-        Lambda = (3 * A_s)**(1/4) * np.sqrt(numerator / denominator)
-        return Lambda, phi_star, N_star
 
 
 class DoubleWellPotential(InflationaryPotential):
@@ -1137,56 +874,6 @@ class DoubleWell2Potential(DoubleWellPotential):
         phi_end2 = 4 + phi0**2 - 2 * np.sqrt(4 + 2 * phi0**2)
         return (phi2 - phi_end2 - phi0**2 * np.log(phi2 / phi_end2)) / 8
 
-    @classmethod
-    def sr_As2Lambda(cls, A_s, phi_star, N_star, **pot_kwargs):
-        """Get potential amplitude `Lambda` from PPS amplitude `A_s`.
-
-        Find the inflaton amplitude `Lambda` (4th root of potential amplitude)
-        that produces the desired amplitude `A_s` of the primordial power
-        spectrum using the slow-roll approximation.
-
-        Parameters
-        ----------
-        A_s : float or np.ndarray
-            Amplitude `A_s` of the primordial power spectrum.
-        phi_star : float or None
-            Inflaton value at horizon crossing of the pivot scale.
-        N_star : float or None
-            Number of observable e-folds of inflation `N_star`
-            from horizon crossing till the end of inflation.
-
-        Other Parameters
-        ----------------
-        phi0 : float
-            Inflaton distance between local maximum and minima.
-
-        Returns
-        -------
-        Lambda : float or np.ndarray
-            Amplitude parameter `Lambda` for the Double-Well potential.
-        phi_star : float
-            Inflaton value at horizon crossing of the pivot scale.
-        N_star : float
-            Number of observable e-folds of inflation `N_star`
-            from horizon crossing till the end of inflation.
-
-        """
-        phi0 = pot_kwargs.pop('phi0')
-        if N_star is None:
-            N_star = cls.phi2efolds(phi_shifted=phi_star, phi0=phi0)
-        elif phi_star is None:
-            # phi = phi_end * np.exp((-8 * N_star - phi_end**2) / (2 * phi0**2))  # inaccurate
-            phi_end_shifted = phi0 - np.sqrt(4 + phi0**2 - 2 * np.sqrt(4 + 2 * phi0**2))
-            phi_sample = np.linspace(phi_end_shifted, phi0, 100000)[1:-1]
-            N_sample = cls.phi2efolds(phi_shifted=phi_sample, phi0=phi0)
-            logN2phi = interp1d(np.log(N_sample), phi_sample)
-            phi_star = float(logN2phi(np.log(N_star)))
-        else:
-            raise Exception("Need to specify either N_star or phi_star. "
-                            "The respective other should be None.")
-        Lambda = (3 * A_s)**(1/4) * np.sqrt(8 * pi * phi_star) * phi0 / (phi0**2 - phi_star**2)
-        return Lambda, phi_star, N_star
-
 
 class DoubleWell4Potential(DoubleWellPotential):
     """Quartic Double-Well potential: `V(phi) = Lambda**4 * (1 - (phi/phi0)**4)**2`.
@@ -1201,17 +888,6 @@ class DoubleWell4Potential(DoubleWellPotential):
 
     def __init__(self, **pot_kwargs):
         super().__init__(p=4, **pot_kwargs)
-
-    @cached_property
-    def phi_end(self):  # noqa: D102
-        phi0 = self.phi0
-        # Approximate solution:
-        phi_0_phi_end = (77 * 2**(5 / 6) * phi0**(17 / 3) / 3981312
-                         - 35 * 2**(1 / 6) * phi0**(13 / 3) / 165888
-                         - 2**(5 / 6) * phi0**(5 / 3) / 96
-                         + 2**(1 / 6) * phi0**(1 / 3) / 2
-                         + np.sqrt(2) * phi0**3 / 768)
-        return phi0 * (1 - phi_0_phi_end)
 
     @staticmethod
     def phi_end_squared(phi0):
@@ -1258,55 +934,6 @@ class DoubleWell4Potential(DoubleWellPotential):
         phi2 = (phi_shifted - phi0)**2
         phi_end2 = cls.phi_end_squared(phi0=phi0)
         return (phi2 - phi_end2 + phi0**4 * (1/phi2 - 1/phi_end2)) / 16
-
-    @classmethod
-    def sr_As2Lambda(cls, A_s, phi_star, N_star, **pot_kwargs):
-        """Get potential amplitude `Lambda` from PPS amplitude `A_s`.
-
-        Find the inflaton amplitude `Lambda` (4th root of potential amplitude)
-        that produces the desired amplitude `A_s` of the primordial power
-        spectrum using the slow-roll approximation.
-
-        Parameters
-        ----------
-        A_s : float or np.ndarray
-            Amplitude `A_s` of the primordial power spectrum.
-        phi_star : float or None
-            Inflaton value at horizon crossing of the pivot scale.
-        N_star : float or None
-            Number of observable e-folds of inflation `N_star`
-            from horizon crossing till the end of inflation.
-
-        Other Parameters
-        ----------------
-        phi0 : float
-            Inflaton distance between local maximum and minima.
-
-        Returns
-        -------
-        Lambda : float or np.ndarray
-            Amplitude parameter `Lambda` for the Double-Well potential.
-        phi_star : float
-            Inflaton value at horizon crossing of the pivot scale.
-        N_star : float
-            Number of observable e-folds of inflation `N_star`
-            from horizon crossing till the end of inflation.
-
-        """
-        phi0 = pot_kwargs.pop('phi0')
-        if N_star is None:
-            N_star = cls.phi2efolds(phi_shifted=phi_star, phi0=phi0)
-        elif phi_star is None:
-            phi_end_shifted = phi0 - np.sqrt(cls.phi_end_squared(phi0=phi0))
-            phi_sample = np.linspace(phi_end_shifted, phi0, 100000)[1:-1]
-            N_sample = cls.phi2efolds(phi_shifted=phi_sample, phi0=phi0)
-            logN2phi = interp1d(np.log(N_sample), phi_sample)
-            phi_star = float(logN2phi(np.log(N_star)))
-        else:
-            raise Exception("Need to specify either N_star or phi_star. "
-                            "The respective other should be None.")
-        Lambda = (768 * A_s)**(1/4) * np.sqrt(pi * phi_star**3) * phi0**2 / (phi0**4 - phi_star**4)
-        return Lambda, phi_star, N_star
 
 
 class TmodelPotential(InflationaryPotential):

--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -16,7 +16,8 @@ import primpy.potentials as pp
                                              (pp.NaturalPotential, dict(phi0=100)),
                                              (pp.DoubleWellPotential, dict(phi0=100, p=2)),
                                              (pp.DoubleWell2Potential, dict(phi0=100)),
-                                             (pp.DoubleWell4Potential, dict(phi0=100))])
+                                             (pp.DoubleWell4Potential, dict(phi0=100)),
+                                             (pp.TmodelPotential, dict(p=2, alpha=1))])
 @pytest.mark.parametrize('Lambda, phi', [(1, 1.), (2e-3, 10.)])
 def test_inflationary_potentials(Pot, pot_kwargs, Lambda, phi):
     with pytest.raises(Exception):

--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -4,6 +4,7 @@ import pytest
 from pytest import approx
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
+from primpy.exceptionhandling import PrimpyError, PrimpyWarning
 import primpy.potentials as pp
 
 
@@ -58,6 +59,10 @@ def test_inflationary_potentials(Pot, pot_kwargs, Lambda, phi):
     Pot(A_s=2e-9, N_star=60, **pot_kwargs)
     pot2 = Pot(A_s=2e-9, phi_star=5, **pot_kwargs)
     assert pot2.Lambda == approx(L)
+    with pytest.warns(PrimpyWarning):
+        Pot(A_s=2e-9, N_star=60, Lambda=1e-2, **pot_kwargs)
+    with pytest.raises(PrimpyError):
+        Pot(A_s=2e-9, **pot_kwargs)
 
 
 @pytest.mark.parametrize('Lambda, phi', [(1, 1), (0.0025, 20)])

--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -55,6 +55,9 @@ def test_inflationary_potentials(Pot, pot_kwargs, Lambda, phi):
     pot.get_epsilon_2(phi=phi)
     pot.get_epsilon_3(phi=phi)
     pot.get_epsilon_4(phi=phi)
+    Pot(A_s=2e-9, N_star=60, **pot_kwargs)
+    pot2 = Pot(A_s=2e-9, phi_star=5, **pot_kwargs)
+    assert pot2.Lambda == approx(L)
 
 
 @pytest.mark.parametrize('Lambda, phi', [(1, 1), (0.0025, 20)])

--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -195,6 +195,8 @@ def test_natural_slow_roll(pot_kwargs, N_star):
     n_s = Pot.sr_Nstar2ns(N_star=N_star, **pot_kwargs)
     assert 0.8 < n_s < 1
     assert Pot.sr_ns2Nstar(n_s=n_s, **pot_kwargs) == approx(N_star)
+    with pytest.raises(PrimpyError):
+        Pot.sr_ns2Nstar(n_s=n_s, phi0=1)
 
     r = Pot.sr_Nstar2r(N_star=N_star, **pot_kwargs)
     assert 1e-4 < r < 1

--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -132,6 +132,9 @@ def test_doublewell_inflation_V(Pot, phi0):
          (2 - pot.p + 2 * (-1 + 2 * pot.p) * (-1 + phi / phi0)**pot.p)) / (phi0 - phi)**3,
         rtol=1e-12, atol=1e-12)
 
+    with pytest.warns(DeprecationWarning):
+        Pot.phi2efolds(phi0/2, phi0=phi0)
+
 
 def test_starobinsky_inflation_power_to_potential():
     pot = pp.StarobinskyPotential(Lambda=1e-3)
@@ -187,6 +190,9 @@ def test_starobinsky_slow_roll(N_star):
     assert r == approx(aprx, rel=1e-3)
     assert Pot.sr_r2Nstar(r=r) == approx(N_star)
 
+    with pytest.warns(DeprecationWarning):
+        Pot.phi2efolds(phi=5)
+
 
 @pytest.mark.parametrize('pot_kwargs', [dict(phi0=10), dict(phi0=100), dict(phi0=1000)])
 @pytest.mark.parametrize('N_star', [20, 60, 90])
@@ -201,6 +207,9 @@ def test_natural_slow_roll(pot_kwargs, N_star):
     r = Pot.sr_Nstar2r(N_star=N_star, **pot_kwargs)
     assert 1e-4 < r < 1
     assert Pot.sr_r2Nstar(r=r, **pot_kwargs) == approx(N_star)
+
+    with pytest.warns(DeprecationWarning):
+        Pot.phi2efolds(phi=pot_kwargs['phi0']/2, phi0=pot_kwargs['phi0'])
 
 
 @pytest.mark.parametrize('a_feature', [0.1, 0.01])

--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -18,7 +18,7 @@ import primpy.potentials as pp
                                              (pp.DoubleWell2Potential, dict(phi0=100)),
                                              (pp.DoubleWell4Potential, dict(phi0=100)),
                                              (pp.TmodelPotential, dict(p=2, alpha=1))])
-@pytest.mark.parametrize('Lambda, phi', [(1, 1.), (2e-3, 10.)])
+@pytest.mark.parametrize('Lambda, phi', [(1, 3.), (2e-3, 10.)])
 def test_inflationary_potentials(Pot, pot_kwargs, Lambda, phi):
     with pytest.raises(Exception):
         kwargs = pot_kwargs.copy()
@@ -32,7 +32,9 @@ def test_inflationary_potentials(Pot, pot_kwargs, Lambda, phi):
     assert pot.dV(phi=phi) > 0
     pot.d2V(phi=phi)
     pot.d3V(phi=phi)
+    pot.d4V(phi=phi)
     assert pot.inv_V(V=Lambda**4/2) > 0
+    assert 0 < pot.phi_end < phi
     L, p, N = pot.sr_As2Lambda(A_s=2e-9, phi_star=None, N_star=60, **pot_kwargs)
     assert L > 0
     assert p > 0
@@ -43,6 +45,16 @@ def test_inflationary_potentials(Pot, pot_kwargs, Lambda, phi):
     assert 0 < N < 100
     with pytest.raises(Exception):
         pot.sr_As2Lambda(A_s=2e-9, phi_star=5, N_star=60, **pot_kwargs)
+    e1V = pot.get_epsilon_1V(phi=phi)
+    assert 0 < e1V < 1
+    pot.get_epsilon_2V(phi=phi)
+    pot.get_epsilon_3V(phi=phi)
+    pot.get_epsilon_4V(phi=phi)
+    e1 = pot.get_epsilon_1(phi=phi)
+    assert 0 < e1 < 1
+    pot.get_epsilon_2(phi=phi)
+    pot.get_epsilon_3(phi=phi)
+    pot.get_epsilon_4(phi=phi)
 
 
 @pytest.mark.parametrize('Lambda, phi', [(1, 1), (0.0025, 20)])

--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -17,7 +17,7 @@ import primpy.potentials as pp
                                              (pp.DoubleWellPotential, dict(phi0=100, p=2)),
                                              (pp.DoubleWell2Potential, dict(phi0=100)),
                                              (pp.DoubleWell4Potential, dict(phi0=100))])
-@pytest.mark.parametrize('Lambda, phi', [(1, 1), (2e-3, 10)])
+@pytest.mark.parametrize('Lambda, phi', [(1, 1.), (2e-3, 10.)])
 def test_inflationary_potentials(Pot, pot_kwargs, Lambda, phi):
     with pytest.raises(Exception):
         kwargs = pot_kwargs.copy()
@@ -32,20 +32,16 @@ def test_inflationary_potentials(Pot, pot_kwargs, Lambda, phi):
     pot.d2V(phi=phi)
     pot.d3V(phi=phi)
     assert pot.inv_V(V=Lambda**4/2) > 0
-    if type(pot) is pp.DoubleWellPotential:
-        with pytest.raises(NotImplementedError):
-            pot.sr_As2Lambda(A_s=2e-9, phi_star=None, N_star=60, **pot_kwargs)
-    else:
-        L, p, N = pot.sr_As2Lambda(A_s=2e-9, phi_star=None, N_star=60, **pot_kwargs)
-        assert L > 0
-        assert p > 0
-        assert N == 60
-        L, p, N = pot.sr_As2Lambda(A_s=2e-9, phi_star=5, N_star=None, **pot_kwargs)
-        assert L > 0
-        assert p == 5
-        assert 0 < N < 100
-        with pytest.raises(Exception):
-            pot.sr_As2Lambda(A_s=2e-9, phi_star=5, N_star=60, **pot_kwargs)
+    L, p, N = pot.sr_As2Lambda(A_s=2e-9, phi_star=None, N_star=60, **pot_kwargs)
+    assert L > 0
+    assert p > 0
+    assert N == 60
+    L, p, N = pot.sr_As2Lambda(A_s=2e-9, phi_star=5, N_star=None, **pot_kwargs)
+    assert L > 0
+    assert p == 5
+    assert 0 < N < 100
+    with pytest.raises(Exception):
+        pot.sr_As2Lambda(A_s=2e-9, phi_star=5, N_star=60, **pot_kwargs)
 
 
 @pytest.mark.parametrize('Lambda, phi', [(1, 1), (0.0025, 20)])


### PR DESCRIPTION
Implement T-model potential and do a general little overhaul of the potential handling:

* Add methods for the potential slow-roll parameters to each potential.
* Use the potential slow-roll parameters for `A_s` to `Lambda` conversion function.
* Add slow-roll conversion functions between `phi` and `N` to each potential.


# Checklist:

- [x] I have performed a self-review of my own code.
- [x] My code is PEP8 compliant (`flake8 --max-line-length 99 primpy tests`).
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `anesthetic/__version__.py`.
