### PR TITLE
Fix as guessing in cobayawrapper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.14.0
+:Version: 2.14.1
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/cobaya_wrapper/slowroll_pps.py
+++ b/cobaya_wrapper/slowroll_pps.py
@@ -45,9 +45,10 @@ class SlowRollPPS(ExternalPrimordialPowerSpectrum):
         K = 0
         t_eval = np.logspace(5, 12, (12 - 5) * 1000 + 1)
         pot = self.Pot(**pot_kwargs)
-        Lambda, phi_i, _ = pot.sr_As2Lambda(A_s=A_s, N_star=N_star+10, phi_star=None, **pot_kwargs)
-        if 'phi0' in pot_kwargs and phi_i >= phi0:
-            phi_i = 0.999 * phi0
+        Lambda, _, _ = pot.sr_As2Lambda(A_s=A_s, N_star=N_star, phi_star=None, **pot_kwargs)
+        phi_i = pot.sr_N2phi(N=90)  # choose sufficiently high N to accommodate even highest N_star
+        if 'phi0' in pot_kwargs and phi_i > phi0:
+            phi_i = phi0
         for i in range(11):
             pot = self.Pot(Lambda=Lambda, **pot_kwargs)
             eq = InflationEquations(K=K, potential=pot, track_eta=False)

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,3 +1,3 @@
 """Version file for primpy."""
 
-__version__ = '2.14.0'
+__version__ = '2.14.1'

--- a/primpy/initialconditions.py
+++ b/primpy/initialconditions.py
@@ -68,6 +68,8 @@ class SlowRollIC(InitialConditions):
             self.x_ini = self.t_i
             self.x_end = self.x_end
             self.dphidt_i = -self.dV_i / (3 * self.H_i)
+            # TODO: Make the initial dphidt more accurate by using only d2phidt2=0 in the e.o.m.,
+            #       not dphidt=0 in Friedmann 1.
         elif isinstance(self.equations, InflationEquationsN):
             self.x_ini = self.N_i
             self.x_end = self.x_end

--- a/primpy/oscode_solver.py
+++ b/primpy/oscode_solver.py
@@ -91,8 +91,12 @@ def solve_oscode(background, k, **kwargs):
             # set idx_beg to 0 if horizon starts out too small:
             idx_beg = 0 if idx_beg.size == 0 else idx_beg[-1]
         idx_end = np.argwhere(b._logaH - np.log(ki) > np.log(fac_end)).ravel()[0]
-        # set minimum for idx_end, needed e.g. in KD for superhorizon modes:
-        idx_end = idx_end if idx_end - idx_beg > b._logaH.size//20 else idx_beg + b._logaH.size//20
+        if b._N[idx_end] - b._N[idx_beg] < 10:
+            # For KD, for very large modes it can happen that they never go sub-horizon, and
+            # therefore `idx_end` will be set equal (or close to equal) to `idx_beg`. These modes
+            # nonetheless need to be evolved a bit past inflationstart before they properly freeze
+            # in. Hence, we additionally require that from `beg` to `end` at least 10 e-folds pass:
+            idx_end = np.argwhere(b._N - b._N[idx_beg] > 10).ravel()[0]
         if b.independent_variable == 't':
             p = PerturbationT(background=b, k=ki, idx_beg=idx_beg, idx_end=idx_end, **kwargs)
         elif b.independent_variable == '_N':


### PR DESCRIPTION
In the past I have used `sr_As2Lambda` to "guess" an appropriate `Lambda` for some target `A_s` and at the same time I used the free by-product of `phi_star` to guess an appropriate initial inflaton value `phi_i` that produces enough e-folds for some target `N_star`. To that end I multiplied by some factor, e.g. `phi_i = 1.1 * phi_star`. However, depending on the inflation model, such a factor of 1.1 can lead to extremely high values of `N_tot`, much beyond what is needed for the given `N_star`. Hence it is better to estimate `phi_i` from some `N_tot = N_star + const`, which is why I simply passed `N_star+10` to `sr_As2Lambda`. While that indeed provides a more reliable guess for `phi_i`, it (in hindsight obviously) renders the guess for `Lambda` and `n_s` etc. incorrect. We should not mix guessing `Lambda` and guessing `phi_i`, better to do them independently, which is fixed for the cobaya wrapper in this PR.

Along the ride, I improve the handling of the stopping criterion for evolving the curvature perturbations, removing the hacky, ugly way of requiring a minimum number of indices from `beg` to `end`, and replacing it by requiring a minimum number of e-folds. This only affects fully integrated power spectra, not the slow-roll approximations, so this does not affect anything in the slow-roll cobaya wrapper, but I discovered this issue when working on the slow-roll spectra, because I normalised them with the fully numerical solutions.

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] My code is PEP8 compliant (`flake8 --max-line-length 99 primpy tests`).
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `anesthetic/__version__.py`.
