### PR TITLE
dense Oscode output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.14.1
+:Version: 2.15.0
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,3 +1,3 @@
 """Version file for primpy."""
 
-__version__ = '2.14.1'
+__version__ = '2.15.0'

--- a/primpy/efolds/perturbations.py
+++ b/primpy/efolds/perturbations.py
@@ -32,10 +32,10 @@ class ScalarModeN(ScalarMode):
         super(ScalarModeN, self).__init__(background=background, k=k, **kwargs)
         self._set_independent_variable('_N')
         if 'num_eval' in kwargs and kwargs['num_eval'] > 0:
-            self._N_eval = np.logspace(self.background._N[self.idx_beg],
+            self._N_eval = np.linspace(self.background._N[self.idx_beg],
                                        self.background._N[self.idx_end],
                                        kwargs['num_eval'])
-            self.N_eval = np.logspace(self.background.N[self.idx_beg],
+            self.N_eval = np.linspace(self.background.N[self.idx_beg],
                                       self.background.N[self.idx_end],
                                       kwargs['num_eval'])
             self.x_eval = self._N_eval
@@ -134,10 +134,10 @@ class TensorModeN(TensorMode):
         super(TensorModeN, self).__init__(background=background, k=k, **kwargs)
         self._set_independent_variable('_N')
         if 'num_eval' in kwargs and kwargs['num_eval'] > 0:
-            self._N_eval = np.logspace(self.background._N[self.idx_beg],
+            self._N_eval = np.linspace(self.background._N[self.idx_beg],
                                        self.background._N[self.idx_end],
                                        kwargs['num_eval'])
-            self.N_eval = np.logspace(self.background.N[self.idx_beg],
+            self.N_eval = np.linspace(self.background.N[self.idx_beg],
                                       self.background.N[self.idx_end],
                                       kwargs['num_eval'])
             self.x_eval = self._N_eval

--- a/primpy/efolds/perturbations.py
+++ b/primpy/efolds/perturbations.py
@@ -31,6 +31,16 @@ class ScalarModeN(ScalarMode):
     def __init__(self, background, k, **kwargs):
         super(ScalarModeN, self).__init__(background=background, k=k, **kwargs)
         self._set_independent_variable('_N')
+        if 'num_eval' in kwargs and kwargs['num_eval'] > 0:
+            self._N_eval = np.logspace(self.background._N[self.idx_beg],
+                                       self.background._N[self.idx_end],
+                                       kwargs['num_eval'])
+            self.N_eval = np.logspace(self.background.N[self.idx_beg],
+                                      self.background.N[self.idx_end],
+                                      kwargs['num_eval'])
+            self.x_eval = self._N_eval
+        else:
+            self.x_eval = None
 
     def __call__(self, x, y):
         """Vector of derivatives."""
@@ -123,6 +133,16 @@ class TensorModeN(TensorMode):
     def __init__(self, background, k, **kwargs):
         super(TensorModeN, self).__init__(background=background, k=k, **kwargs)
         self._set_independent_variable('_N')
+        if 'num_eval' in kwargs and kwargs['num_eval'] > 0:
+            self._N_eval = np.logspace(self.background._N[self.idx_beg],
+                                       self.background._N[self.idx_end],
+                                       kwargs['num_eval'])
+            self.N_eval = np.logspace(self.background.N[self.idx_beg],
+                                      self.background.N[self.idx_end],
+                                      kwargs['num_eval'])
+            self.x_eval = self._N_eval
+        else:
+            self.x_eval = None
 
     def __call__(self, x, y):
         """Vector of derivatives."""

--- a/primpy/oscode_solver.py
+++ b/primpy/oscode_solver.py
@@ -6,7 +6,11 @@ from primpy.time.perturbations import PerturbationT
 from primpy.efolds.perturbations import PerturbationN
 
 
-def solve_oscode(background, k, **kwargs):
+def solve_oscode(background, k,
+                 vacuum=None, drop_closed_large_scales=True,
+                 fac_beg=0, fac_end=100,
+                 rtol=5e-5, even_grid=False, num_eval=0,
+                 **kwargs):
     """Run :func:`pyoscode.solve` and store information for post-processing.
 
     This is a wrapper around :func:`pyoscode.solve` to calculate the solution
@@ -20,18 +24,16 @@ def solve_oscode(background, k, **kwargs):
         the frequency and damping term passed to oscode.
     k : int, float, np.ndarray
         Comoving wavenumber used to evolve the Mukhanov-Sasaki equation.
-
-    Other Parameters
-    ----------------
-    y0 : (float, float, float, float)
-        Initial values (y0_1, dy0_1, y0_2, dy0_2) of perturbations and
-        their derivatives for two independent solutions. The perturbations
-        (y0_1, y0_2) are scaled with `k` and their derivatives with `k**2`
-        in order to produce freeze-out values of about order(~1).
-        default : determined by input inflationary potential
-    rtol : float
-        Tolerance passed to pyoscode.
-        default : 5e-5
+    vacuum : tuple
+        Set of vacuum initial conditions to be computed.
+        Choose any of ('k', 'HD', 'RST').
+        default : ('RST', )
+    drop_closed_large_scales : bool
+        If true, this will set the PPS for closed universes on comoving
+        scales of `k < 1` to close to zero (1e-30). Strictly speaking, the
+        PPS for closed universes is only defined for rational numbers
+        `k > 2`.
+        default : True
     fac_beg : int, float
         Integration of the mode evolution starts when the considered
         scale 1/k is within a factor of `fac_beg` of the comoving Hubble
@@ -43,20 +45,28 @@ def solve_oscode(background, k, **kwargs):
         scale 1/k exceeds the comoving Hubble horizon by a factor of
         `fac_end`, i.e. when `1/k > 1/aH * fac_end`.
         default : 100
+    rtol : float
+        Tolerance passed to pyoscode.
+        default : 5e-5
     even_grid : bool
         Set this to True if the grid of the independent variable is
         equally spaced.
         default : False
-    vacuum : tuple
-        Set of vacuum initial conditions to be computed.
-        Choose any of ('RST', ).
-        default : ('RST', )
-    drop_closed_large_scales : bool
-        If true, this will set the PPS for closed universes on comoving
-        scales of `k < 1` to close to zero (1e-30). Strictly speaking, the
-        PPS for closed universes is only defined for rational numbers
-        `k > 2`.
-        default : True
+    num_eval : int
+        Number of interpolation points used for dense output.
+        This number is applied dynamically to the range determined from the
+        parameters `fac_beg` and `fac_end`.
+        Zero means no dense output.
+        default : 0
+
+    Other Parameters
+    ----------------
+    y0 : (float, float, float, float)
+        Initial values (y0_1, dy0_1, y0_2, dy0_2) of perturbations and
+        their derivatives for two independent solutions. The perturbations
+        (y0_1, y0_2) are scaled with `k` and their derivatives with `k**2`
+        in order to produce freeze-out values of about order(~1).
+        default : determined by input inflationary potential
 
     Returns
     -------
@@ -68,20 +78,15 @@ def solve_oscode(background, k, **kwargs):
 
     """
     assert 'tol' not in kwargs
-    y0 = kwargs.pop('y0', background.potential.perturbation_ic)
-    rtol = kwargs.pop('rtol', 5e-5)
-    fac_beg = kwargs.pop('fac_beg', 0)
-    fac_end = kwargs.pop('fac_end', 100)
-    even_grid = kwargs.pop('even_grid', False)
-    vacuum = kwargs.get('vacuum', ('k', 'RST'))
-    drop_closed_large_scales = kwargs.pop('drop_closed_large_scales', True)
     b = background
+    vacuum = ('RST', ) if vacuum is None else vacuum
+    y0 = kwargs.pop('y0', b.potential.perturbation_ic)
     if isinstance(k, int) or isinstance(k, float):
         k = np.atleast_1d(k)
         return_pps = False
     else:
         return_pps = True
-    PPS = PrimordialPowerSpectrum(background=b, k=k, **kwargs)
+    PPS = PrimordialPowerSpectrum(background=b, k=k, vacuum=vacuum)
     # stop integration sufficiently after mode has crossed the horizon (lazy for loop):
     for i, ki in enumerate(k):
         if fac_beg == 0:
@@ -98,22 +103,27 @@ def solve_oscode(background, k, **kwargs):
             # in. Hence, we additionally require that from `beg` to `end` at least 10 e-folds pass:
             idx_end = np.argwhere(b._N - b._N[idx_beg] > 10).ravel()[0]
         if b.independent_variable == 't':
-            p = PerturbationT(background=b, k=ki, idx_beg=idx_beg, idx_end=idx_end, **kwargs)
+            p = PerturbationT(background=b, k=ki, vacuum=vacuum,
+                              idx_beg=idx_beg, idx_end=idx_end, num_eval=num_eval)
         elif b.independent_variable == '_N':
-            p = PerturbationN(background=b, k=ki, idx_beg=idx_beg, idx_end=idx_end, **kwargs)
+            p = PerturbationN(background=b, k=ki, vacuum=vacuum,
+                              idx_beg=idx_beg, idx_end=idx_end, num_eval=num_eval)
         else:
             raise NotImplementedError()
         oscode_sol = []
         for mode in [p.scalar, p.tensor]:
             for num in range(2):
-                oscode_sol.append(pyoscode.solve(ts=b.x[idx_beg:idx_end+1],
-                                                 ti=b.x[idx_beg], tf=b.x[idx_end],
-                                                 ws=np.log(mode.ms_frequency), logw=True,
-                                                 gs=mode.ms_damping, logg=False,
-                                                 x0=y0[2*num],
-                                                 dx0=y0[2*num+1],
-                                                 rtol=rtol, even_grid=even_grid))
-        p.oscode_postprocessing(oscode_sol=oscode_sol, **kwargs)
+                oscode_sol.append(pyoscode.solve(
+                    ts=b.x[idx_beg:idx_end+1],
+                    ti=b.x[idx_beg], tf=b.x[idx_end],
+                    ws=np.log(mode.ms_frequency), logw=True,
+                    gs=mode.ms_damping, logg=False,
+                    x0=y0[2*num],
+                    dx0=y0[2*num+1],
+                    rtol=rtol, even_grid=even_grid,
+                    t_eval=mode.x_eval,
+                ))
+        p.oscode_postprocessing(oscode_sol=oscode_sol, vacuum=vacuum)
         if ki < 1 and b.K == +1 and drop_closed_large_scales:
             p.scalar.P_s_RST = 1e-30
         for vac in vacuum:

--- a/primpy/perturbations.py
+++ b/primpy/perturbations.py
@@ -68,6 +68,9 @@ class Perturbation(ABC):
                                                   y2_i=y2[0], dy2_i=dy2[0])
                 uk_end = a * np.nanmedian(y1[-5:]) + b * np.nanmedian(y2[-5:])
                 setattr(mode, 'P_%s_%s' % (mode.tag, vac), np.abs(uk_end)**2 * mode.pps_norm)
+                if mode.x_eval is not None:
+                    uk = a * mode.one.y_eval[0] + b * mode.two.y_eval[0]
+                    setattr(mode, 'P_%s_%s_eval' % (mode.tag, vac), np.abs(uk)**2 * mode.pps_norm)
 
     @staticmethod
     def _get_coefficients_a_b(uk_i, duk_i, y1_i, dy1_i, y2_i, dy2_i):

--- a/primpy/time/perturbations.py
+++ b/primpy/time/perturbations.py
@@ -30,6 +30,13 @@ class ScalarModeT(ScalarMode):
     def __init__(self, background, k, **kwargs):
         super(ScalarModeT, self).__init__(background=background, k=k, **kwargs)
         self._set_independent_variable('t')
+        if 'num_eval' in kwargs and kwargs['num_eval'] > 0:
+            self.t_eval = np.logspace(np.log10(self.background.t[self.idx_beg]),
+                                      np.log10(self.background.t[self.idx_end]),
+                                      kwargs['num_eval'])
+            self.x_eval = self.t_eval
+        else:
+            self.x_eval = None
 
     def __call__(self, x, y):
         """Vector of derivatives."""
@@ -121,6 +128,13 @@ class TensorModeT(TensorMode):
     def __init__(self, background, k, **kwargs):
         super(TensorModeT, self).__init__(background=background, k=k, **kwargs)
         self._set_independent_variable('t')
+        if 'num_eval' in kwargs and kwargs['num_eval'] > 0:
+            self.t_eval = np.logspace(np.log10(self.background.t[self.idx_beg]),
+                                      np.log10(self.background.t[self.idx_end]),
+                                      kwargs['num_eval'])
+            self.x_eval = self.t_eval
+        else:
+            self.x_eval = None
 
     def __call__(self, x, y):
         """Vector of derivatives."""

--- a/tests/test_perturbations.py
+++ b/tests/test_perturbations.py
@@ -307,14 +307,14 @@ def test_dense_output_time_vs_efolds(K, k):
     assert pert_t.tensor.t_eval.size == num_eval
     assert pert_n.tensor._N_eval.size == num_eval
     assert pert_n.tensor.N_eval.size == num_eval
-    assert pert_t.scalar.one.y_eval[0].real.size == num_eval
-    assert pert_n.scalar.one.y_eval[0].real.size == num_eval
-    assert pert_t.scalar.two.y_eval[0].real.size == num_eval
-    assert pert_n.scalar.two.y_eval[0].real.size == num_eval
-    assert pert_t.tensor.one.y_eval[0].real.size == num_eval
-    assert pert_n.tensor.one.y_eval[0].real.size == num_eval
-    assert pert_t.tensor.two.y_eval[0].real.size == num_eval
-    assert pert_n.tensor.two.y_eval[0].real.size == num_eval
+    assert pert_t.scalar.one.y_eval.shape == (2, num_eval)
+    assert pert_n.scalar.one.y_eval.shape == (2, num_eval)
+    assert pert_t.scalar.two.y_eval.shape == (2, num_eval)
+    assert pert_n.scalar.two.y_eval.shape == (2, num_eval)
+    assert pert_t.tensor.one.y_eval.shape == (2, num_eval)
+    assert pert_n.tensor.one.y_eval.shape == (2, num_eval)
+    assert pert_t.tensor.two.y_eval.shape == (2, num_eval)
+    assert pert_n.tensor.two.y_eval.shape == (2, num_eval)
 
     # check that time and e-folds solutions match for PPS observable
     assert pert_t.scalar.P_s_RST == approx(pert_n.scalar.P_s_RST, rel=5e-3)


### PR DESCRIPTION
Introduce `num_eval` kwarg for dense output from `solve_oscode`

* The `num_eval` kwarg specifies how many interpolating steps should be taken in the oscode integration interval. This is different from the otherwise common use of a `t_eval` kwarg that specifies the exact time points, because here we need to dynamically adjust to the integration interval derived from the factors `fac_beg` and `fac_end` kwargs.
* Additionally most of the kwargs are made explicit for better documentation and better tracking. In particular the `vacuum` kwarg is being passed explicitly between the various methods.


# Checklist:

- [x] I have performed a self-review of my own code.
- [x] My code is PEP8 compliant (`flake8 --max-line-length 99 primpy tests`).
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `anesthetic/__version__.py`.
