### PR TITLE
Sample wreh and rhoreh

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.15.0
+:Version: 2.16.0
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/cobaya_wrapper/slowroll_pps.py
+++ b/cobaya_wrapper/slowroll_pps.py
@@ -2,6 +2,7 @@
 import numpy as np
 from cobaya_wrapper.powerlaw_pps import ExternalPrimordialPowerSpectrum
 from primpy.exceptionhandling import PrimpyError, StepSizeError
+from primpy.units import mp_GeV, lp_iGeV
 import primpy.potentials as pp
 from primpy.time.inflation import InflationEquationsT as InflationEquations
 from primpy.events import InflationEvent
@@ -16,7 +17,7 @@ class SlowRollPPS(ExternalPrimordialPowerSpectrum):
         self.Pot = pp.InflationaryPotential
 
     def get_can_support_params(self):
-        return {'A_s', 'n_s', 'N_star', 'rho_reh_GeV', 'phi0', 'p', 'alpha'}
+        return {'A_s', 'n_s', 'N_star', 'rho_reh_GeV', 'w_reh', 'phi0', 'p', 'alpha'}
 
     def get_can_provide_params(self):
         return {'N_star',  # 'phi_star', 'V_star', 'H_star',
@@ -60,6 +61,8 @@ class SlowRollPPS(ExternalPrimordialPowerSpectrum):
                       atol=1e-18, rtol=2.22045e-14, method='DOP853')
             if not b.success:
                 raise StepSizeError(b.message)
+            if rho_reh_GeV > (1/3*(1/2*b.dphidt**2+b.potential.V(b.phi))*mp_GeV/lp_iGeV**3)**(1/4):
+                raise PrimpyError(f"Unrealistic reheating scenario with rho_reh={rho_reh_GeV}.")
             if N_star is not None and n_s is None:
                 N_star = N_star
                 b.calibrate_scale_factor(N_star=N_star, rho_reh_GeV=rho_reh_GeV)

--- a/cobaya_wrapper/slowroll_pps.py
+++ b/cobaya_wrapper/slowroll_pps.py
@@ -61,13 +61,18 @@ class SlowRollPPS(ExternalPrimordialPowerSpectrum):
                       atol=1e-18, rtol=2.22045e-14, method='DOP853')
             if not b.success:
                 raise StepSizeError(b.message)
-            if rho_reh_GeV > (1/3*(1/2*b.dphidt**2+b.potential.V(b.phi))*mp_GeV/lp_iGeV**3)**(1/4):
+            rho_end_GeV = (1/3 * (1/2 * b.dphidt[b.inflation_mask][-1]**2
+                                  + b.potential.V(b.phi[b.inflation_mask][-1]))
+                           * mp_GeV / lp_iGeV**3)**(1/4)
+            if rho_reh_GeV > rho_end_GeV:
                 raise PrimpyError(f"Unrealistic reheating scenario with rho_reh={rho_reh_GeV}.")
-            if N_star is not None and n_s is None:
+            if w_reh is not None and rho_reh_GeV is not None:
+                b.calibrate_scale_factor(calibration_method='reheating',
+                                         rho_reh_GeV=rho_reh_GeV, w_reh=w_reh)
+            elif N_star is not None and n_s is None:
                 N_star = N_star
-                b.calibrate_scale_factor(N_star=N_star, rho_reh_GeV=rho_reh_GeV)
-            elif w_reh is not None and rho_reh_GeV is not None:
-                b.calibrate_scale_factor(rho_reh_GeV=rho_reh_GeV, w_reh=w_reh)
+                b.calibrate_scale_factor(calibration_method='N_star', N_star=N_star,
+                                         rho_reh_GeV=rho_reh_GeV)
             else:
                 N_star = min(N_star, b.N_tot-0.1)
                 b.calibrate_scale_factor(N_star=N_star, rho_reh_GeV=rho_reh_GeV)

--- a/cobaya_wrapper/slowroll_pps.py
+++ b/cobaya_wrapper/slowroll_pps.py
@@ -29,6 +29,7 @@ class SlowRollPPS(ExternalPrimordialPowerSpectrum):
         A_s = params_values_dict.get('A_s')
         n_s = params_values_dict.get('n_s')
         rho_reh_GeV = params_values_dict.get('rho_reh_GeV')
+        w_reh = params_values_dict.get('w_reh')
         pot_kwargs = {}
         if 'phi0' in params_values_dict.keys():
             phi0 = params_values_dict.get('phi0')
@@ -59,11 +60,15 @@ class SlowRollPPS(ExternalPrimordialPowerSpectrum):
                       atol=1e-18, rtol=2.22045e-14, method='DOP853')
             if not b.success:
                 raise StepSizeError(b.message)
-            N_star = N_star if n_s is None else min(N_star, b.N_tot-0.1)
-            b.calibrate_scale_factor(N_star=N_star, rho_reh_GeV=rho_reh_GeV)
-            if n_s is not None:
-                b.set_ns(n_s=n_s, rho_reh_GeV=rho_reh_GeV,
-                         N_star_min=20, N_star_max=min(75, b.N_tot-0.1))
+            if N_star is not None and n_s is None:
+                N_star = N_star
+                b.calibrate_scale_factor(N_star=N_star, rho_reh_GeV=rho_reh_GeV)
+            elif w_reh is not None and rho_reh_GeV is not None:
+                b.calibrate_scale_factor(rho_reh_GeV=rho_reh_GeV, w_reh=w_reh)
+            else:
+                N_star = min(N_star, b.N_tot-0.1)
+                b.calibrate_scale_factor(N_star=N_star, rho_reh_GeV=rho_reh_GeV)
+                b.set_ns(n_s=n_s, rho_reh_GeV=rho_reh_GeV, N_star_min=20, N_star_max=N_star)
             # check whether the target A_s is met
             if abs(b.A_s - A_s) < atol + rtol * A_s:
                 break  # when the target is met, exit the loop

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,3 +1,3 @@
 """Version file for primpy."""
 
-__version__ = '2.15.0'
+__version__ = '2.16.0'

--- a/primpy/inflation.py
+++ b/primpy/inflation.py
@@ -580,7 +580,7 @@ class InflationEquations(Equations, ABC):
                                 or DeltaN_reh == 0 or w_reh == 1/3):
                             # assume instant reheating
                             sol.DeltaN_reh = 0
-                            sol.w_reh = np.nan
+                            sol.w_reh = 1/3
                             sol.rho_reh_mp4 = 3/2 * sol.V_end
                             sol.rho_reh_GeV = (sol.rho_reh_mp4 * mp_GeV / lp_iGeV**3)**(1/4)
                         elif w_reh is not None and DeltaN_reh is not None and rho_reh_GeV is None:
@@ -693,7 +693,7 @@ class InflationEquations(Equations, ABC):
                     if (w_reh is None and DeltaN_reh is None) or DeltaN_reh == 0 or w_reh == 1/3:
                         # assume instant reheating
                         sol.DeltaN_reh = 0
-                        sol.w_reh = np.nan
+                        sol.w_reh = 1/3
                         sol.rho_reh_mp4 = 3/2 * sol.V_end
                         sol.rho_reh_GeV = (sol.rho_reh_mp4 * mp_GeV / lp_iGeV**3)**(1/4)
                         sol._N_reh = sol._N_end

--- a/primpy/inflation.py
+++ b/primpy/inflation.py
@@ -592,7 +592,11 @@ class InflationEquations(Equations, ABC):
                             sol.rho_reh_GeV = (sol.rho_reh_mp4 * mp_GeV / lp_iGeV**3)**(1/4)
                         elif w_reh is not None and DeltaN_reh is None and rho_reh_GeV is not None:
                             # reheating from w_reh and rho_reh
-                            pass
+                            sol.w_reh = w_reh
+                            sol.rho_reh_GeV = rho_reh_GeV
+                            sol.rho_reh_mp4 = rho_reh_GeV**4 / mp_GeV * lp_iGeV**3
+                            sol.DeltaN_reh = -(1+w_reh)/3 * np.log(2/3*sol.rho_reh_mp4 / sol.V_end)
+                            sol.N_end -= 3/4 * (1/3 - w_reh) * sol.DeltaN_reh
                         else:
                             raise ValueError(
                                 f"Something in the reheating setup went wrong. Keep in mind that "

--- a/tests/test_inflation.py
+++ b/tests/test_inflation.py
@@ -432,6 +432,9 @@ def test_reheating(K, DeltaN_reh, w_reh):
     assert bist.N_star == approx(bisn.N_star, rel=1e-5)
     assert bist.N_dagg == approx(bisn.N_dagg, rel=1e-5)
     assert bist.N_reh == approx(bisn.N_reh, rel=1e-5)
+    assert bist.w_reh == approx(bisn.w_reh, rel=1e-5)
+    assert bist.DeltaN_reh == approx(bisn.DeltaN_reh, rel=1e-5)
+    assert bist.rho_reh_GeV == approx(bisn.rho_reh_GeV, rel=1e-5)
 
 
 @pytest.mark.parametrize('K', [-1, 0, +1])

--- a/tests/test_inflation.py
+++ b/tests/test_inflation.py
@@ -407,12 +407,13 @@ def test_sol_time_efolds(K):
 
 
 @pytest.mark.parametrize('K', [-1, 0, +1])
-@pytest.mark.parametrize('DeltaN_reh', [0, 5])
-@pytest.mark.parametrize('w_reh', [-1/3, 0, 1/3, 1])
-def test_reheating(K, DeltaN_reh, w_reh):
+@pytest.mark.parametrize('DeltaN_reh', [None, 0, 5])
+@pytest.mark.parametrize('w_reh', [None, -1/3, 0, 1/3, 1])
+@pytest.mark.parametrize('rho_reh_GeV', [None, 1e9])
+def test_reheating(K, DeltaN_reh, w_reh, rho_reh_GeV):
     pot = StarobinskyPotential(Lambda=3.3e-3)
     N_i = 14
-    phi_i = 6
+    phi_i = 6.5
     t_i = 7e4
     h = 0.7
     eq_t = InflationEquationsT(K=K, potential=pot)
@@ -423,18 +424,32 @@ def test_reheating(K, DeltaN_reh, w_reh):
             InflationEvent(eq_t, -1, terminal=True)]
     ev_N = [InflationEvent(eq_N, +1, terminal=False),
             InflationEvent(eq_N, -1, terminal=True)]
-    bist = solve(ic=ic_t, events=ev_t, dense_output=True, method='DOP853', rtol=1e-12)
-    bisn = solve(ic=ic_N, events=ev_N, dense_output=True, method='DOP853', rtol=1e-12)
-    bist.calibrate_scale_factor(calibration_method='reheating', h=h,
-                                DeltaN_reh=DeltaN_reh, w_reh=w_reh)
-    bisn.calibrate_scale_factor(calibration_method='reheating', h=h,
-                                DeltaN_reh=DeltaN_reh, w_reh=w_reh)
-    assert bist.N_star == approx(bisn.N_star, rel=1e-5)
-    assert bist.N_dagg == approx(bisn.N_dagg, rel=1e-5)
-    assert bist.N_reh == approx(bisn.N_reh, rel=1e-5)
-    assert bist.w_reh == approx(bisn.w_reh, rel=1e-5)
-    assert bist.DeltaN_reh == approx(bisn.DeltaN_reh, rel=1e-5)
-    assert bist.rho_reh_GeV == approx(bisn.rho_reh_GeV, rel=1e-5)
+
+    if (w_reh is not None and w_reh != 1/3 and DeltaN_reh is not None and DeltaN_reh > 0
+        and rho_reh_GeV is not None) or (
+            not (w_reh is None and DeltaN_reh is None and rho_reh_GeV is None)
+            and ((w_reh is None and DeltaN_reh is not None and DeltaN_reh > 0 and
+                  rho_reh_GeV is not None) or
+                 w_reh is None and DeltaN_reh is None or
+                 w_reh is None and rho_reh_GeV is None and DeltaN_reh > 0 or
+                 DeltaN_reh is None and rho_reh_GeV is None and w_reh != 1/3)):
+        with pytest.raises(PrimpyError):
+            bist = solve(ic=ic_t, events=ev_t, dense_output=True, method='DOP853', rtol=1e-12)
+            bist.calibrate_scale_factor(calibration_method='reheating', h=h, w_reh=w_reh,
+                                        DeltaN_reh=DeltaN_reh, rho_reh_GeV=rho_reh_GeV)
+    else:
+        bist = solve(ic=ic_t, events=ev_t, dense_output=True, method='DOP853', rtol=1e-12)
+        bisn = solve(ic=ic_N, events=ev_N, dense_output=True, method='DOP853', rtol=1e-12)
+        bist.calibrate_scale_factor(calibration_method='reheating', h=h,
+                                    DeltaN_reh=DeltaN_reh, w_reh=w_reh, rho_reh_GeV=rho_reh_GeV)
+        bisn.calibrate_scale_factor(calibration_method='reheating', h=h,
+                                    DeltaN_reh=DeltaN_reh, w_reh=w_reh, rho_reh_GeV=rho_reh_GeV)
+        assert bist.N_star == approx(bisn.N_star, rel=1e-5)
+        assert bist.N_dagg == approx(bisn.N_dagg, rel=1e-5)
+        assert bist.N_reh == approx(bisn.N_reh, rel=1e-5)
+        assert bist.w_reh == approx(bisn.w_reh, rel=1e-5)
+        assert bist.DeltaN_reh == approx(bisn.DeltaN_reh, rel=1e-5)
+        assert bist.rho_reh_GeV == approx(bisn.rho_reh_GeV, rel=1e-5)
 
 
 @pytest.mark.parametrize('K', [-1, 0, +1])

--- a/tests/test_inflation.py
+++ b/tests/test_inflation.py
@@ -564,9 +564,9 @@ def test_calibration_input_errors():
         b_sol.calibrate_scale_factor(calibration_method='reheating', w_reh=0, DeltaN_reh=-5)
     with pytest.raises(ValueError):
         b_sol.calibrate_scale_factor(calibration_method='reheating', w_reh=-1, DeltaN_reh=5)
-    with pytest.raises(ValueError):
+    with pytest.raises(PrimpyError):
         b_sol.calibrate_scale_factor(calibration_method='reheating', w_reh=0, DeltaN_reh=None)
-    with pytest.raises(ValueError):
+    with pytest.raises(PrimpyError):
         b_sol.calibrate_scale_factor(calibration_method='reheating', w_reh=None, DeltaN_reh=5)
     with pytest.raises(ValueError):
         b_sol.calibrate_scale_factor(background=b, N_star=None)
@@ -601,9 +601,9 @@ def test_calibration_input_errors():
         b_sol.calibrate_scale_factor(calibration_method='reheating', h=h, w_reh=0, DeltaN_reh=-5)
     with pytest.raises(ValueError):  # w_reh < -1/3
         b_sol.calibrate_scale_factor(calibration_method='reheating', h=h, w_reh=-1, DeltaN_reh=5)
-    with pytest.raises(ValueError):  # w_reh provided but DeltaN_reh missing
+    with pytest.raises(PrimpyError):  # w_reh provided but DeltaN_reh missing
         b_sol.calibrate_scale_factor(calibration_method='reheating', h=h, w_reh=0, DeltaN_reh=None)
-    with pytest.raises(ValueError):  # DeltaN_reh provided but w_reh missing
+    with pytest.raises(PrimpyError):  # DeltaN_reh provided but w_reh missing
         b_sol.calibrate_scale_factor(calibration_method='reheating', h=h, w_reh=None, DeltaN_reh=5)
     with pytest.raises(NotImplementedError):  # non-existent calibration_method
         b_sol.calibrate_scale_factor(calibration_method='spam', h=h)


### PR DESCRIPTION
This PR allows sampling the energy density at the end of reheating `rho_reh` together with the equation-of-state parameter of reheating `w_reh`, the spectral index `n_s` and the number of inflationary e-folds `N_star` of the scale factor after horizon crossing of the pivot scale become derived parameters.

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] My code is PEP8 compliant (`flake8 --max-line-length 99 primpy tests`).
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `anesthetic/__version__.py`.
