### PR TITLE
Fix catching of unrealistic reheating for `N_reh > N0`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.16.0
+:Version: 2.16.1
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,3 +1,3 @@
 """Version file for primpy."""
 
-__version__ = '2.16.0'
+__version__ = '2.16.1'


### PR DESCRIPTION
When sampling w.r.t. `w_reh` and `rho_reh` the case of `N_reh > N0` can happen and hasn't been caught so far in Cobaya runs. This PR fixes this and discards those cases too.

# Checklist:

- [ ] I have performed a self-review of my own code.
- [ ] My code is PEP8 compliant (`flake8 --max-line-length 99 primpy tests`).
- [ ] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
- [ ] New and existing unit tests pass locally with my changes (`python -m pytest`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `anesthetic/__version__.py`.
