### PR TITLE
Fix a bug in the reheating calculations when running with `w_reh` and `rho_reh`

### DIFF
--- a/cobaya_wrapper/slowroll_pps.py
+++ b/cobaya_wrapper/slowroll_pps.py
@@ -23,7 +23,7 @@ class SlowRollPPS(ExternalPrimordialPowerSpectrum):
     def get_can_provide_params(self):
         return {'N_star',  # 'phi_star', 'V_star', 'H_star',
                 'N_end', 'phi_end', 'V_end', 'H_end',
-                'N_reh', 'w_reh', 'DeltaN_reh',
+                'N_reh', 'w_reh', 'DeltaN_reh', 'rho_reh_GeV'
                 'A_s', 'n_s', 'n_run', 'n_runrun', 'A_t', 'n_t', 'r'}
 
     def calculate(self, state, want_derived=True, **params_values_dict):
@@ -72,7 +72,6 @@ class SlowRollPPS(ExternalPrimordialPowerSpectrum):
                     b.calibrate_scale_factor(calibration_method='reheating',
                                              rho_reh_GeV=rho_reh_GeV, w_reh=w_reh)
                 elif N_star is not None and n_s is None:
-                    N_star = N_star
                     b.calibrate_scale_factor(calibration_method='N_star', N_star=N_star,
                                              rho_reh_GeV=rho_reh_GeV)
                 else:


### PR DESCRIPTION
There was a mistake in the calculation of `DeltaN_reh` when calibrating the scale factor through reheating, which this PR addresses.

Note that calibration with `N_star` is unaffected, so that was correct also before this PR.


# Checklist:

- [ ] I have performed a self-review of my own code.
- [ ] My code is PEP8 compliant (`flake8 --max-line-length 99 primpy tests`).
- [ ] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
- [ ] New and existing unit tests pass locally with my changes (`python -m pytest`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `anesthetic/__version__.py`.
