### PR TITLE
Update readthedocs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,4 +11,4 @@ Fixes # (issue)
 - [ ] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
 - [ ] New and existing unit tests pass locally with my changes (`python -m pytest`).
 - [ ] I have added tests that prove my fix is effective or that my feature works.
-- [ ] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `anesthetic/__version__.py`.
+- [ ] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `primpy/__version__.py`.

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.12"
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,16 +10,15 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.12"
+  jobs:
+    pre_install:
+      - python -m pip install -U pip setuptools wheel
+    install:
+      - python -m pip install -U --upgrade-strategy eager --no-cache-dir -r requirements.txt
+      - python -m pip install -U --upgrade-strategy eager --no-cache-dir -r docs/requirements.txt
+      - python -m pip install -U --upgrade-strategy eager --no-cache-dir .
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py
    fail_on_warning: true
-
-# Optionally declare the Python requirements required to build your docs
-python:
-   install:
-   - requirements: requirements.txt
-   - requirements: docs/requirements.txt
-   - method: pip
-     path: .

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.18.0
+:Version: 2.18.1
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 sphinx
 sphinx-autodoc-typehints
 sphinx_copybutton
-sphinx_rtd_theme
+sphinx_rtd_theme>=3.0.0
 numpydoc
 matplotlib

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,3 +1,3 @@
 """Version file for primpy."""
 
-__version__ = '2.18.0'
+__version__ = '2.18.1'


### PR DESCRIPTION
The docs aren't building properly, attempting to fix this here. 

First suspicion: python packages are not upgraded to the latest version.

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] My code is PEP8 compliant (`flake8 --max-line-length 99 primpy tests`).
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
- [x] New and existing unit tests pass locally with my changes (`python -m pytest`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `primpy/__version__.py`.
