### PR TITLE
Integrate `RadionGaugePotential` into cobaya wrapper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ primpy: calculations for the primordial Universe
 ================================================
 :primpy: calculations for the primordial Universe
 :Author: Lukas Hergt
-:Version: 2.18.1
+:Version: 2.18.2
 :Homepage: https://github.com/lukashergt/primpy
 :Documentation: https://primpy.readthedocs.io
 

--- a/cobaya_wrapper/slowroll_pps.py
+++ b/cobaya_wrapper/slowroll_pps.py
@@ -166,3 +166,17 @@ class TmodelSlowRollPPS(SlowRollPPS):
     def initialize(self):
         super().initialize()
         self.Pot = pp.TmodelPotential
+
+
+class RadionGaugeSlowRollPPS(SlowRollPPS):
+
+    def initialize(self):
+        super().initialize()
+        self.Pot = pp.RadionGaugePotential
+
+
+class RadionGauge2SlowRollPPS(SlowRollPPS):
+
+    def initialize(self):
+        super().initialize()
+        self.Pot = pp.RadionGauge2Potential

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -78,6 +78,7 @@ autodoc_default_options = {
     'undoc-members': False,
 }
 autosummary_generate = True
+autodoc_use_legacy_class_based = True  # Sphinx 9.x: fall back to legacy (pre-9.0) class-based autodoc
 
 
 # -- Options for autosectionlabel------------------------------------------

--- a/primpy/__version__.py
+++ b/primpy/__version__.py
@@ -1,3 +1,3 @@
 """Version file for primpy."""
 
-__version__ = '2.18.1'
+__version__ = '2.18.2'


### PR DESCRIPTION
This adds the `RadionGaugePotential` to the available potentials in the cobaya wrapper.

# Checklist:

- [x] I have performed a self-review of my own code.
- [x] My code is PEP8 compliant (`flake8 --max-line-length 99 primpy tests`).
- [x] My code contains compliant docstrings (`pydocstyle --convention=numpy primpy`).
- [ ] New and existing unit tests pass locally with my changes (`python -m pytest`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have appropriately incremented the [semantic version number](https://semver.org/) in both `README.rst` and `primpy/__version__.py`.
